### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@lava-nc/lava-committers


### PR DESCRIPTION
Add @lava-nc/lava-committers to CODEOWNERS ensuring
only committers can merge patches for lava-nc/lava