### PR TITLE
Enable RefPort connections

### DIFF
--- a/lava/magma/compiler/compiler.py
+++ b/lava/magma/compiler/compiler.py
@@ -32,6 +32,7 @@ from lava.magma.core.model.model import AbstractProcessModel
 from lava.magma.core.model.nc.model import AbstractNcProcessModel
 from lava.magma.core.model.py.model import AbstractPyProcessModel
 from lava.magma.core.model.sub.model import AbstractSubProcessModel
+from lava.magma.core.process.ports.ports import AbstractPort, VarPort
 from lava.magma.core.process.process import AbstractProcess
 from lava.magma.core.resources import CPU, NeuroCore
 from lava.magma.core.run_configs import RunConfig
@@ -497,7 +498,7 @@ class Compiler:
             )
 
     @staticmethod
-    def _get_port_dtype(port: "AbstractPort",
+    def _get_port_dtype(port: AbstractPort,
                         proc_model: ty.Type[AbstractProcessModel]) -> type:
         """Returns the type of a port, as specified in the corresponding
          ProcessModel."""
@@ -506,7 +507,7 @@ class Compiler:
         if hasattr(proc_model, port.name):
             return getattr(proc_model, port.name).d_type
         # Implicitly created VarPorts
-        elif hasattr(proc_model, port.var.name):
+        elif isinstance(port, VarPort):
             return getattr(proc_model, port.var.name).d_type
         # Port has different name in Process and ProcessModel
         else:

--- a/lava/magma/compiler/compiler.py
+++ b/lava/magma/compiler/compiler.py
@@ -50,7 +50,6 @@ class Compiler:
             self._compile_config.update(compile_cfg)
 
     # ToDo: (AW) Clean this up by avoiding redundant search paths
-    # ToDo: (AW) @PP Please include RefPorts/VarPorts in connection tracing
     def _find_processes(self,
                         proc: AbstractProcess,
                         seen_procs: ty.List[AbstractProcess] = None) \
@@ -70,14 +69,14 @@ class Compiler:
         new_list: ty.List[AbstractProcess] = []
 
         # add processes connecting to the main process
-        for in_port in proc.in_ports:
+        for in_port in proc.in_ports.members + proc.var_ports.members:
             for con in in_port.in_connections:
                 new_list.append(con.process)
             for con in in_port.out_connections:
                 new_list.append(con.process)
 
         # add processes connecting from the main process
-        for out_port in proc.out_ports:
+        for out_port in proc.out_ports.members + proc.ref_ports.members:
             for con in out_port.in_connections:
                 new_list.append(con.process)
             for con in out_port.out_connections:
@@ -273,7 +272,7 @@ class Compiler:
                     v = [VarInitializer(v.name, v.shape, v.init, v.id)
                          for v in p.vars]
                     ports = (list(p.in_ports) + list(p.out_ports)
-                             + list(p.ref_ports))
+                             + list(p.ref_ports) + list(p.var_ports))
                     ports = [PortInitializer(pt.name,
                                              pt.shape,
                                              getattr(pm, pt.name).d_type,

--- a/lava/magma/compiler/utils.py
+++ b/lava/magma/compiler/utils.py
@@ -16,6 +16,6 @@ class VarInitializer:
 class PortInitializer:
     name: str
     shape: ty.Tuple[int, ...]
-    d_type: ty.Type[np.intc]
+    d_type: type
     port_type: str
     size: int

--- a/lava/magma/compiler/utils.py
+++ b/lava/magma/compiler/utils.py
@@ -1,8 +1,6 @@
 import typing as ty
 from dataclasses import dataclass
 
-import numpy as np
-
 
 @dataclass
 class VarInitializer:

--- a/lava/magma/core/process/ports/ports.py
+++ b/lava/magma/core/process/ports/ports.py
@@ -391,10 +391,15 @@ class RefPort(AbstractRVPort, AbstractSrcPort):
             # Create a VarPort to wrap Var
             vp = VarPort(v)
             # Propagate name and parent process of Var to VarPort
-            vp.name = v.name + "_port"
+            vp.name = "_" + v.name + "_implicit_port"
             if v.process is not None:
                 # Only assign when parent process is already assigned
                 vp.process = v.process
+                # VarPort Name could shadow existing attribute
+                if hasattr(v.process, vp.name):
+                    raise AssertionError(
+                        "Name of implicit VarPort might conflict"
+                        " with existing attribute.")
             var_ports.append(vp)
         # Connect RefPort to VarPorts that wrap Vars
         self.connect(var_ports)

--- a/tests/magma/compiler/test_compiler.py
+++ b/tests/magma/compiler/test_compiler.py
@@ -13,8 +13,9 @@ from lava.magma.core.model.sub.model import AbstractSubProcessModel
 from lava.magma.core.sync.domain import SyncDomain
 from lava.magma.core.sync.protocol import AbstractSyncProtocol
 from lava.magma.core.sync.protocols.async_protocol import AsyncProtocol
-from lava.magma.core.process.ports.ports import InPort, OutPort
-from lava.magma.core.model.py.ports import PyInPort, PyOutPort
+from lava.magma.core.process.ports.ports import (
+    InPort, OutPort, RefPort, VarPort)
+from lava.magma.core.model.py.ports import PyInPort, PyOutPort, PyRefPort
 from lava.magma.core.run_configs import RunConfig
 from lava.magma.core.model.py.type import LavaPyType
 from lava.magma.core.process.variable import Var, VarServer
@@ -29,6 +30,7 @@ class ProcA(AbstractProcess):
         # Use ReduceOp to allow for multiple input connections
         self.inp = InPort(shape=(1,), reduce_op=ReduceSum)
         self.out = OutPort(shape=(1,))
+        self.ref = RefPort(shape=(10,))
 
 
 # Another minimal process (does not matter that it's identical to ProcA)
@@ -39,6 +41,7 @@ class ProcB(AbstractProcess):
         self.inp = InPort(shape=(1,), reduce_op=ReduceSum)
         self.out = OutPort(shape=(1,))
         self.some_var = Var((10,), init=10)
+        self.var_port = VarPort(self.some_var)
 
 
 # Another minimal process (does not matter that it's identical to ProcA)
@@ -74,6 +77,7 @@ class ProtocolB(AbstractSyncProtocol):
 class PyProcModelA(AbstractPyProcessModel):
     inp: PyInPort = LavaPyType(PyInPort.VEC_DENSE, int)
     out: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, int)
+    ref: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
 
     def run(self):
         pass
@@ -86,6 +90,7 @@ class PyProcModelB(AbstractPyProcessModel):
     inp: PyInPort = LavaPyType(PyInPort.VEC_DENSE, int)
     out: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, int)
     some_var: int = LavaPyType(int, int)
+    var_port: PyInPort = LavaPyType(PyInPort.VEC_DENSE, int)
 
     def run(self):
         pass
@@ -261,6 +266,32 @@ class TestCompiler(unittest.TestCase):
         self.assertEqual(set(procs2), all_procs)
         self.assertEqual(set(procs4), all_procs)
         self.assertEqual(set(procs6), all_procs)
+
+    def test_find_process_ref_ports(self):
+        """Checks finding all processes for RefPort connection.
+        [p1 -> ref/var -> p2 -> in/out -> p3]"""
+
+        # Create processes
+        p1, p2, p3 = (
+            ProcA(),
+            ProcB(),
+            ProcC()
+        )
+        # Create complicated circular structure with joins and forks
+        p1.ref.connect(p2.var_port)
+        p2.out.connect(p3.inp)
+
+        # Regardless where we start searching...
+        c = Compiler()
+        procs1 = c._find_processes(p1)
+        procs2 = c._find_processes(p2)
+        procs3 = c._find_processes(p3)
+
+        # ...we will find all of them
+        all_procs = {p1, p2, p3}
+        self.assertEqual(set(procs1), all_procs)
+        self.assertEqual(set(procs2), all_procs)
+        self.assertEqual(set(procs3), all_procs)
 
     def test_find_proc_models(self):
         """Check finding of ProcModels that implement a Process."""
@@ -657,6 +688,36 @@ class TestCompiler(unittest.TestCase):
         self.assertIsInstance(chb[0], ChannelBuilderMp)
         self.assertEqual(chb[0].src_process, p.procs.proc1)
         self.assertEqual(chb[0].dst_process, p.procs.proc2)
+
+    def test_create_channel_builders_ref_ports(self):
+        """Checks creation of channel builders when a process is connected
+        using a RefPort to another process."""
+
+        # create a process with a RefPort (source)
+        src = ProcA()
+
+        # create a process with a var (destination)
+        dst = ProcB()
+
+        # connect them using RefPort and VarPort
+        src.ref.connect(dst.var_port)
+
+        # Create a manual proc_map
+        proc_map = {
+            src: PyProcModelA,
+            dst: PyProcModelB
+        }
+
+        # Create channel builders
+        c = Compiler()
+        cbs = c._create_channel_builders(proc_map)
+
+        # This should result in 1 channel builder
+        from lava.magma.compiler.builder import ChannelBuilderMp
+        self.assertEqual(len(cbs), 1)
+        self.assertIsInstance(cbs[0], ChannelBuilderMp)
+        self.assertEqual(cbs[0].src_process, src)
+        self.assertEqual(cbs[0].dst_process, dst)
 
     # ToDo: (AW) @YS/@JM Please fix unit test by passing run_srv_builders to
     #  _create_exec_vars when ready

--- a/tests/magma/compiler/test_compiler.py
+++ b/tests/magma/compiler/test_compiler.py
@@ -689,7 +689,7 @@ class TestCompiler(unittest.TestCase):
 
     def test_create_channel_builders_ref_ports(self):
         """Checks creation of channel builders when a process is connected
-        using a RefPort to another process."""
+        using a RefPort to another process VarPort."""
 
         # Create a process with a RefPort (source)
         src = ProcA()
@@ -699,6 +699,36 @@ class TestCompiler(unittest.TestCase):
 
         # Connect them using RefPort and VarPort
         src.ref.connect(dst.var_port)
+
+        # Create a manual proc_map
+        proc_map = {
+            src: PyProcModelA,
+            dst: PyProcModelB
+        }
+
+        # Create channel builders
+        c = Compiler()
+        cbs = c._create_channel_builders(proc_map)
+
+        # This should result in 1 channel builder
+        from lava.magma.compiler.builder import ChannelBuilderMp
+        self.assertEqual(len(cbs), 1)
+        self.assertIsInstance(cbs[0], ChannelBuilderMp)
+        self.assertEqual(cbs[0].src_process, src)
+        self.assertEqual(cbs[0].dst_process, dst)
+
+    def test_create_channel_builders_ref_ports_implicit(self):
+        """Checks creation of channel builders when a process is connected
+        using a RefPort to another process Var (implicit VarPort)."""
+
+        # Create a process with a RefPort (source)
+        src = ProcA()
+
+        # Create a process with a var (destination)
+        dst = ProcB()
+
+        # Connect them using RefPort and Var (creates implicitly a VarPort)
+        src.ref.connect_var(dst.some_var)
 
         # Create a manual proc_map
         proc_map = {

--- a/tests/magma/compiler/test_compiler.py
+++ b/tests/magma/compiler/test_compiler.py
@@ -272,13 +272,11 @@ class TestCompiler(unittest.TestCase):
         [p1 -> ref/var -> p2 -> in/out -> p3]"""
 
         # Create processes
-        p1, p2, p3 = (
-            ProcA(),
-            ProcB(),
-            ProcC()
-        )
-        # Create complicated circular structure with joins and forks
+        p1, p2, p3 = ProcA(), ProcB(), ProcC()
+
+        # Connect p1 (RefPort) with p2 (VarPort)
         p1.ref.connect(p2.var_port)
+        # Connect p2 (OutPort) with p3 (InPort)
         p2.out.connect(p3.inp)
 
         # Regardless where we start searching...
@@ -693,13 +691,13 @@ class TestCompiler(unittest.TestCase):
         """Checks creation of channel builders when a process is connected
         using a RefPort to another process."""
 
-        # create a process with a RefPort (source)
+        # Create a process with a RefPort (source)
         src = ProcA()
 
-        # create a process with a var (destination)
+        # Create a process with a var (destination)
         dst = ProcB()
 
-        # connect them using RefPort and VarPort
+        # Connect them using RefPort and VarPort
         src.ref.connect(dst.var_port)
 
         # Create a manual proc_map


### PR DESCRIPTION
-added RefPorts and VarPorts to find_processes
-added var_ports to compile_proc_models
-channels are now also build for RefPort -> VarPort connections
-added unit tests

Next step is to add RefPorts in the synchronization protocol to allow sending data.