### PR TITLE
Reduced the number of channels between service and process (#1)

### DIFF
--- a/src/lava/magma/compiler/builder.py
+++ b/src/lava/magma/compiler/builder.py
@@ -188,7 +188,6 @@ class PyProcessBuilder(AbstractProcessBuilder):
 
         Any Py{In/Out/Ref}Ports must be strict sub-types of Py{In/Out/Ref}Ports.
         """
-
         for name, port_init in self.py_ports.items():
             lt = self._get_lava_type(name)
             if not isinstance(lt.cls, type):
@@ -421,22 +420,13 @@ class PyProcessBuilder(AbstractProcessBuilder):
             setattr(pm, name, port)
 
         for port in self.csp_rs_recv_port.values():
-            if "service_to_process_cmd" in port.name:
-                pm.service_to_process_cmd = port
-                continue
-            if "service_to_process_req" in port.name:
-                pm.service_to_process_req = port
-                continue
-            if "service_to_process_data" in port.name:
-                pm.service_to_process_data = port
+            if "service_to_process" in port.name:
+                pm.service_to_process = port
                 continue
 
         for port in self.csp_rs_send_port.values():
-            if "process_to_service_ack" in port.name:
-                pm.process_to_service_ack = port
-                continue
-            if "process_to_service_data" in port.name:
-                pm.process_to_service_data = port
+            if "process_to_service" in port.name:
+                pm.process_to_service = port
                 continue
 
         # Initialize Vars
@@ -535,18 +525,12 @@ class RuntimeServiceBuilder(AbstractRuntimeServiceBuilder):
         rs.model_ids = self._model_ids
 
         for port in self.csp_proc_send_port.values():
-            if "service_to_process_cmd" in port.name:
-                rs.service_to_process_cmd.append(port)
-            if "service_to_process_req" in port.name:
-                rs.service_to_process_req.append(port)
-            if "service_to_process_data" in port.name:
-                rs.service_to_process_data.append(port)
+            if "service_to_process" in port.name:
+                rs.service_to_process.append(port)
 
         for port in self.csp_proc_recv_port.values():
-            if "process_to_service_ack" in port.name:
-                rs.process_to_service_ack.append(port)
-            if "process_to_service_data" in port.name:
-                rs.process_to_service_data.append(port)
+            if "process_to_service" in port.name:
+                rs.process_to_service.append(port)
 
         for port in self.csp_send_port.values():
             if "service_to_runtime_ack" in port.name:

--- a/src/lava/magma/compiler/builder.py
+++ b/src/lava/magma/compiler/builder.py
@@ -533,18 +533,12 @@ class RuntimeServiceBuilder(AbstractRuntimeServiceBuilder):
                 rs.process_to_service.append(port)
 
         for port in self.csp_send_port.values():
-            if "service_to_runtime_ack" in port.name:
-                rs.service_to_runtime_ack = port
-            elif "service_to_runtime_data" in port.name:
-                rs.service_to_runtime_data = port
+            if "service_to_runtime" in port.name:
+                rs.service_to_runtime = port
 
         for port in self.csp_recv_port.values():
-            if "runtime_to_service_cmd" in port.name:
-                rs.runtime_to_service_cmd = port
-            elif "runtime_to_service_req" in port.name:
-                rs.runtime_to_service_req = port
-            elif "runtime_to_service_data" in port.name:
-                rs.runtime_to_service_data = port
+            if "runtime_to_service" in port.name:
+                rs.runtime_to_service = port
 
         return rs
 

--- a/src/lava/magma/compiler/compiler.py
+++ b/src/lava/magma/compiler/compiler.py
@@ -722,50 +722,23 @@ class Compiler:
             -> ty.Iterable[AbstractChannelBuilder]:
         sync_channel_builders: ty.List[AbstractChannelBuilder] = []
         for sync_domain in rsb:
-            runtime_to_service_cmd = \
+            runtime_to_service = \
                 RuntimeChannelBuilderMp(ChannelType.PyPy,
                                         Runtime,
                                         rsb[sync_domain],
                                         self._create_mgmt_port_initializer(
-                                            f"runtime_to_service_cmd_"
+                                            f"runtime_to_service_"
                                             f"{sync_domain.name}"))
-            sync_channel_builders.append(runtime_to_service_cmd)
+            sync_channel_builders.append(runtime_to_service)
 
-            service_to_runtime_ack = \
+            service_to_runtime = \
                 RuntimeChannelBuilderMp(ChannelType.PyPy,
                                         rsb[sync_domain],
                                         Runtime,
                                         self._create_mgmt_port_initializer(
-                                            f"service_to_runtime_ack_"
+                                            f"service_to_runtime_"
                                             f"{sync_domain.name}"))
-            sync_channel_builders.append(service_to_runtime_ack)
-
-            runtime_to_service_req = \
-                RuntimeChannelBuilderMp(ChannelType.PyPy,
-                                        Runtime,
-                                        rsb[sync_domain],
-                                        self._create_mgmt_port_initializer(
-                                            f"runtime_to_service_req_"
-                                            f"{sync_domain.name}"))
-            sync_channel_builders.append(runtime_to_service_req)
-
-            service_to_runtime_data = \
-                RuntimeChannelBuilderMp(ChannelType.PyPy,
-                                        rsb[sync_domain],
-                                        Runtime,
-                                        self._create_mgmt_port_initializer(
-                                            f"service_to_runtime_data_"
-                                            f"{sync_domain.name}"))
-            sync_channel_builders.append(service_to_runtime_data)
-
-            runtime_to_service_data = \
-                RuntimeChannelBuilderMp(ChannelType.PyPy,
-                                        Runtime,
-                                        rsb[sync_domain],
-                                        self._create_mgmt_port_initializer(
-                                            f"runtime_to_service_data_"
-                                            f"{sync_domain.name}"))
-            sync_channel_builders.append(runtime_to_service_data)
+            sync_channel_builders.append(service_to_runtime)
 
             for process in sync_domain.processes:
                 service_to_process = \

--- a/src/lava/magma/compiler/compiler.py
+++ b/src/lava/magma/compiler/compiler.py
@@ -768,50 +768,23 @@ class Compiler:
             sync_channel_builders.append(runtime_to_service_data)
 
             for process in sync_domain.processes:
-                service_to_process_cmd = \
+                service_to_process = \
                     ServiceChannelBuilderMp(ChannelType.PyPy,
                                             rsb[sync_domain],
                                             process,
                                             self._create_mgmt_port_initializer(
-                                                f"service_to_process_cmd_"
+                                                f"service_to_process_"
                                                 f"{process.id}"))
-                sync_channel_builders.append(service_to_process_cmd)
+                sync_channel_builders.append(service_to_process)
 
-                process_to_service_ack = \
+                process_to_service = \
                     ServiceChannelBuilderMp(ChannelType.PyPy,
                                             process,
                                             rsb[sync_domain],
                                             self._create_mgmt_port_initializer(
-                                                f"process_to_service_ack_"
+                                                f"process_to_service_"
                                                 f"{process.id}"))
-                sync_channel_builders.append(process_to_service_ack)
-
-                service_to_process_req = \
-                    ServiceChannelBuilderMp(ChannelType.PyPy,
-                                            rsb[sync_domain],
-                                            process,
-                                            self._create_mgmt_port_initializer(
-                                                f"service_to_process_req_"
-                                                f"{process.id}"))
-                sync_channel_builders.append(service_to_process_req)
-
-                process_to_service_data = \
-                    ServiceChannelBuilderMp(ChannelType.PyPy,
-                                            process,
-                                            rsb[sync_domain],
-                                            self._create_mgmt_port_initializer(
-                                                f"process_to_service_data_"
-                                                f"{process.id}"))
-                sync_channel_builders.append(process_to_service_data)
-
-                service_to_process_data = \
-                    ServiceChannelBuilderMp(ChannelType.PyPy,
-                                            rsb[sync_domain],
-                                            process,
-                                            self._create_mgmt_port_initializer(
-                                                f"service_to_process_data_"
-                                                f"{process.id}"))
-                sync_channel_builders.append(service_to_process_data)
+                sync_channel_builders.append(process_to_service)
         return sync_channel_builders
 
     def _create_exec_vars(self,

--- a/src/lava/magma/core/model/py/model.py
+++ b/src/lava/magma/core/model/py/model.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 
-from lava.magma.compiler.channels.pypychannel import CspSendPort, CspRecvPort,\
+from lava.magma.compiler.channels.pypychannel import CspSendPort, CspRecvPort, \
     CspSelector
 from lava.magma.core.model.model import AbstractProcessModel
 from lava.magma.core.model.py.ports import AbstractPyPort, PyVarPort
@@ -14,8 +14,7 @@ from lava.magma.runtime.mgmt_token_enums import (
     enum_to_np,
     enum_equal,
     MGMT_COMMAND,
-    MGMT_RESPONSE, REQ_TYPE,
-)
+    MGMT_RESPONSE, )
 
 
 class AbstractPyProcessModel(AbstractProcessModel, ABC):
@@ -33,11 +32,8 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
     def __init__(self):
         super().__init__()
         self.model_id: ty.Optional[int] = None
-        self.service_to_process_cmd: ty.Optional[CspRecvPort] = None
-        self.process_to_service_ack: ty.Optional[CspSendPort] = None
-        self.service_to_process_req: ty.Optional[CspRecvPort] = None
-        self.process_to_service_data: ty.Optional[CspSendPort] = None
-        self.service_to_process_data: ty.Optional[CspRecvPort] = None
+        self.service_to_process: ty.Optional[CspRecvPort] = None
+        self.process_to_service: ty.Optional[CspSendPort] = None
         self.py_ports: ty.List[AbstractPyPort] = []
         self.var_ports: ty.List[PyVarPort] = []
         self.var_id_to_var_map: ty.Dict[int, ty.Any] = {}
@@ -52,11 +48,8 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
                 self.var_ports.append(value)
 
     def start(self):
-        self.service_to_process_cmd.start()
-        self.process_to_service_ack.start()
-        self.service_to_process_req.start()
-        self.process_to_service_data.start()
-        self.service_to_process_data.start()
+        self.service_to_process.start()
+        self.process_to_service.start()
         for p in self.py_ports:
             p.start()
         self.run()
@@ -66,11 +59,8 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
         pass
 
     def join(self):
-        self.service_to_process_cmd.join()
-        self.process_to_service_ack.join()
-        self.service_to_process_req.join()
-        self.process_to_service_data.join()
-        self.service_to_process_data.join()
+        self.service_to_process.join()
+        self.process_to_service.join()
         for p in self.py_ports:
             p.join()
 
@@ -113,96 +103,93 @@ class PyLoihiProcessModel(AbstractPyProcessModel):
         """Retrieves commands from the runtime service to iterate through the
         phases of Loihi and calls their corresponding methods of the
         ProcessModels. The phase is retrieved from runtime service
-        (service_to_process_cmd). After calling the method of a phase of all
+        (service_to_process). After calling the method of a phase of all
         ProcessModels the runtime service is informed about completion. The
         loop ends when the STOP command is received."""
         selector = CspSelector()
         action = 'cmd'
+        phase = PyLoihiProcessModel.Phase.SPK
         while True:
             if action == 'cmd':
-                phase = self.service_to_process_cmd.recv()
-                if enum_equal(phase, MGMT_COMMAND.STOP):
-                    self.process_to_service_ack.send(MGMT_RESPONSE.TERMINATED)
+                cmd = self.service_to_process.recv()
+                if enum_equal(cmd, MGMT_COMMAND.STOP):
+                    self.process_to_service.send(MGMT_RESPONSE.TERMINATED)
                     self.join()
                     return
                 try:
                     # Spiking phase - increase time step
-                    if enum_equal(phase, PyLoihiProcessModel.Phase.SPK):
+                    if enum_equal(cmd, PyLoihiProcessModel.Phase.SPK):
                         self.current_ts += 1
+                        phase = PyLoihiProcessModel.Phase.SPK
                         self.run_spk()
-                        self.process_to_service_ack.send(MGMT_RESPONSE.DONE)
+                        self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Pre-management phase
-                    elif enum_equal(phase, PyLoihiProcessModel.Phase.PRE_MGMT):
+                    elif enum_equal(cmd,
+                                    PyLoihiProcessModel.Phase.PRE_MGMT):
                         # Enable via guard method
+                        phase = PyLoihiProcessModel.Phase.PRE_MGMT
                         if self.pre_guard():
                             self.run_pre_mgmt()
-                        self.process_to_service_ack.send(MGMT_RESPONSE.DONE)
+                        self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Learning phase
-                    elif enum_equal(phase, PyLoihiProcessModel.Phase.LRN):
+                    elif enum_equal(cmd, PyLoihiProcessModel.Phase.LRN):
                         # Enable via guard method
+                        phase = PyLoihiProcessModel.Phase.LRN
                         if self.lrn_guard():
                             self.run_lrn()
-                        self.process_to_service_ack.send(MGMT_RESPONSE.DONE)
+                        self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Post-management phase
-                    elif enum_equal(phase, PyLoihiProcessModel.Phase.POST_MGMT):
+                    elif enum_equal(cmd,
+                                    PyLoihiProcessModel.Phase.POST_MGMT):
                         # Enable via guard method
+                        phase = PyLoihiProcessModel.Phase.POST_MGMT
                         if self.post_guard():
                             self.run_post_mgmt()
-                        self.process_to_service_ack.send(MGMT_RESPONSE.DONE)
+                        self.process_to_service.send(MGMT_RESPONSE.DONE)
                     # Host phase - called at the last time step before STOP
-                    elif enum_equal(phase, PyLoihiProcessModel.Phase.HOST):
+                    elif enum_equal(cmd, PyLoihiProcessModel.Phase.HOST):
+                        phase = PyLoihiProcessModel.Phase.HOST
                         pass
+                    elif enum_equal(cmd, MGMT_COMMAND.GET_DATA) and \
+                            enum_equal(phase, PyLoihiProcessModel.Phase.HOST):
+                        # Handle get/set Var requests from runtime service
+                        self._handle_get_var()
+                    elif enum_equal(cmd,
+                                    MGMT_COMMAND.SET_DATA) and enum_equal(phase,
+                                                                          PyLoihiProcessModel.Phase.HOST):
+                        # Handle get/set Var requests from runtime service
+                        self._handle_set_var()
                     else:
-                        raise ValueError(f"Wrong Phase Info Received : {phase}")
+                        raise ValueError(
+                            f"Wrong Phase Info Received : {cmd}")
                 except Exception as inst:
+                    print("Exception happened")
                     # Inform runtime service about termination
-                    self.process_to_service_ack.send(MGMT_RESPONSE.ERROR)
+                    self.process_to_service.send(MGMT_RESPONSE.ERROR)
                     self.join()
                     raise inst
-
-            elif action == 'req':
-                # Handle get/set Var requests from runtime service
-                self._handle_get_set_var()
             else:
                 # Handle VarPort requests from RefPorts
                 self._handle_var_port(action)
 
-            channel_actions = [(self.service_to_process_cmd, lambda: 'cmd')]
+            channel_actions = [(self.service_to_process, lambda: 'cmd')]
             if enum_equal(phase, PyLoihiProcessModel.Phase.PRE_MGMT) or \
                     enum_equal(phase, PyLoihiProcessModel.Phase.POST_MGMT):
                 for var_port in self.var_ports:
                     for csp_port in var_port.csp_ports:
                         if isinstance(csp_port, CspRecvPort):
                             channel_actions.append((csp_port, lambda: var_port))
-            elif enum_equal(phase, PyLoihiProcessModel.Phase.HOST):
-                channel_actions.append((self.service_to_process_req,
-                                        lambda: 'req'))
             action = selector.select(*channel_actions)
-
-    # FIXME: (PP) might not be able to perform get/set during pause
-    def _handle_get_set_var(self):
-        """Handles all get/set Var requests from the runtime service and calls
-        the corresponding handling methods. The loop ends upon a
-        new command from runtime service after all get/set Var requests have
-        been handled."""
-        # Get the type of the request
-        request = self.service_to_process_req.recv()
-        if enum_equal(request, REQ_TYPE.GET):
-            self._handle_get_var()
-        elif enum_equal(request, REQ_TYPE.SET):
-            self._handle_set_var()
-        else:
-            raise RuntimeError(f"Unknown request type {request}")
 
     def _handle_get_var(self):
         """Handles the get Var command from runtime service."""
         # 1. Receive Var ID and retrieve the Var
-        var_id = self.service_to_process_req.recv()[0].item()
+        var_id = int(self.service_to_process.recv()[0].item())
         var_name = self.var_id_to_var_map[var_id]
         var = getattr(self, var_name)
 
         # 2. Send Var data
-        data_port = self.process_to_service_data
+        data_port = self.process_to_service
         # Header corresponds to number of values
         # Data is either send once (for int) or one by one (array)
         if isinstance(var, int) or isinstance(var, np.integer):
@@ -219,12 +206,12 @@ class PyLoihiProcessModel(AbstractPyProcessModel):
     def _handle_set_var(self):
         """Handles the set Var command from runtime service."""
         # 1. Receive Var ID and retrieve the Var
-        var_id = self.service_to_process_req.recv()[0].item()
+        var_id = int(self.service_to_process.recv()[0].item())
         var_name = self.var_id_to_var_map[var_id]
         var = getattr(self, var_name)
 
         # 2. Receive Var data
-        data_port = self.service_to_process_data
+        data_port = self.service_to_process
         if isinstance(var, int) or isinstance(var, np.integer):
             # First item is number of items (1) - not needed
             data_port.recv()

--- a/src/lava/magma/core/model/py/model.py
+++ b/src/lava/magma/core/model/py/model.py
@@ -155,8 +155,8 @@ class PyLoihiProcessModel(AbstractPyProcessModel):
                         # Handle get/set Var requests from runtime service
                         self._handle_get_var()
                     elif enum_equal(cmd,
-                                    MGMT_COMMAND.SET_DATA) and enum_equal(phase,
-                                                                          PyLoihiProcessModel.Phase.HOST):
+                                    MGMT_COMMAND.SET_DATA) and \
+                            enum_equal(phase, PyLoihiProcessModel.Phase.HOST):
                         # Handle get/set Var requests from runtime service
                         self._handle_set_var()
                     else:

--- a/src/lava/magma/core/process/process.py
+++ b/src/lava/magma/core/process/process.py
@@ -4,17 +4,16 @@
 import typing as ty
 from _collections import OrderedDict
 
+from lava.magma.compiler.executable import Executable
+from lava.magma.core.process.interfaces import \
+    AbstractProcessMember, IdGeneratorSingleton
 from lava.magma.core.process.message_interface_enum import ActorType
-from lava.magma.core.run_conditions import AbstractRunCondition
-from lava.magma.core.run_configs import RunConfig
 from lava.magma.core.process.ports.ports import \
     InPort, OutPort, RefPort, VarPort
 from lava.magma.core.process.variable import Var
-from lava.magma.core.process.interfaces import \
-    AbstractProcessMember, IdGeneratorSingleton
-from lava.magma.compiler.executable import Executable
+from lava.magma.core.run_conditions import AbstractRunCondition
+from lava.magma.core.run_configs import RunConfig
 from lava.magma.runtime.runtime import Runtime
-
 
 # Abbreviation for type annotation in Collection class
 mem_type = ty.Union[InPort, OutPort, RefPort, VarPort, Var, "AbstractProcess"]
@@ -358,7 +357,8 @@ class AbstractProcess(metaclass=ProcessPostInitCaller):
 
     # TODO: (PP) Remove  if condition on blocking as soon as non-blocking
     #  execution is completely implemented
-    def run(self, condition: AbstractRunCondition, run_cfg: RunConfig):
+    def run(self, condition: AbstractRunCondition = None, run_cfg:
+    RunConfig = None):
         """Runs process given RunConfig and RunCondition.
 
         run(..) compiles this and any process connected to this process
@@ -393,7 +393,7 @@ class AbstractProcess(metaclass=ProcessPostInitCaller):
 
         if not self._runtime:
             executable = self.compile(run_cfg)
-            self._runtime = Runtime(condition,
+            self._runtime = Runtime(
                                     executable,
                                     ActorType.MultiProcessing)
             self._runtime.initialize()

--- a/src/lava/magma/core/process/process.py
+++ b/src/lava/magma/core/process/process.py
@@ -357,8 +357,9 @@ class AbstractProcess(metaclass=ProcessPostInitCaller):
 
     # TODO: (PP) Remove  if condition on blocking as soon as non-blocking
     #  execution is completely implemented
-    def run(self, condition: AbstractRunCondition = None, run_cfg:
-    RunConfig = None):
+    def run(self,
+            condition: AbstractRunCondition = None,
+            run_cfg: RunConfig = None):
         """Runs process given RunConfig and RunCondition.
 
         run(..) compiles this and any process connected to this process
@@ -393,8 +394,7 @@ class AbstractProcess(metaclass=ProcessPostInitCaller):
 
         if not self._runtime:
             executable = self.compile(run_cfg)
-            self._runtime = Runtime(
-                                    executable,
+            self._runtime = Runtime(executable,
                                     ActorType.MultiProcessing)
             self._runtime.initialize()
 

--- a/src/lava/magma/runtime/mgmt_token_enums.py
+++ b/src/lava/magma/runtime/mgmt_token_enums.py
@@ -1,12 +1,13 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 # See: https://spdx.org/licenses/
-import numpy as np
 import typing as ty
+
+import numpy as np
 
 
 def enum_to_np(value: ty.Union[int, float],
-               d_type: type = np.int32) -> np.array:
+               d_type: type = np.float64) -> np.array:
     """
     Helper function to convert an int (or EnumInt) or a float to a single value
     np array so as to pass it via the message passing framework. The dtype of
@@ -45,16 +46,10 @@ class MGMT_COMMAND:
     """Signifies a STOP command from one actor to another"""
     PAUSE = enum_to_np(-2)
     """Signifies a PAUSE command from one actor to another"""
-
-
-class REQ_TYPE:
-    """
-    Signifies type of request
-    """
-    GET = enum_to_np(0)
-    """Read a variable"""
-    SET = enum_to_np(1)
-    """Write to a variable"""
+    GET_DATA = enum_to_np(-3)
+    """Signifies Read a variable"""
+    SET_DATA = enum_to_np(-4)
+    """Signifies Write a variable"""
 
 
 class MGMT_RESPONSE:

--- a/src/lava/magma/runtime/runtime.py
+++ b/src/lava/magma/runtime/runtime.py
@@ -57,11 +57,8 @@ class Runtime:
         self._is_initialized = False
         self._is_running = False
         self._is_started = False
-        self.runtime_to_service_cmd: ty.Iterable[CspSendPort] = []
-        self.service_to_runtime_ack: ty.Iterable[CspRecvPort] = []
-        self.runtime_to_service_req: ty.Iterable[CspSendPort] = []
-        self.service_to_runtime_data: ty.Iterable[CspRecvPort] = []
-        self.runtime_to_service_data: ty.Iterable[CspSendPort] = []
+        self.runtime_to_service: ty.Iterable[CspSendPort] = []
+        self.service_to_runtime: ty.Iterable[CspRecvPort] = []
 
     def __del__(self):
         """On destruction, terminate Runtime automatically to
@@ -95,15 +92,9 @@ class Runtime:
         self._is_initialized = True
 
     def _start_ports(self):
-        for port in self.runtime_to_service_cmd:
+        for port in self.runtime_to_service:
             port.start()
-        for port in self.service_to_runtime_ack:
-            port.start()
-        for port in self.runtime_to_service_req:
-            port.start()
-        for port in self.service_to_runtime_data:
-            port.start()
-        for port in self.runtime_to_service_data:
+        for port in self.service_to_runtime:
             port.start()
 
     # ToDo: (AW) Hack: This currently just returns the one and only NodeCfg
@@ -154,16 +145,10 @@ class Runtime:
                         sync_channel_builder.dst_process.set_csp_ports(
                             [channel.dst_port])
                     # TODO: Get rid of if/else ladder
-                    if "runtime_to_service_cmd" in channel.src_port.name:
-                        self.runtime_to_service_cmd.append(channel.src_port)
-                    elif "service_to_runtime_ack" in channel.src_port.name:
-                        self.service_to_runtime_ack.append(channel.dst_port)
-                    elif "runtime_to_service_req" in channel.src_port.name:
-                        self.runtime_to_service_req.append(channel.src_port)
-                    elif "service_to_runtime_data" in channel.src_port.name:
-                        self.service_to_runtime_data.append(channel.dst_port)
-                    elif "runtime_to_service_data" in channel.src_port.name:
-                        self.runtime_to_service_data.append(channel.src_port)
+                    if "runtime_to_service" in channel.src_port.name:
+                        self.runtime_to_service.append(channel.src_port)
+                    elif "service_to_runtime" in channel.src_port.name:
+                        self.service_to_runtime.append(channel.dst_port)
                 elif isinstance(sync_channel_builder, ServiceChannelBuilderMp):
                     if isinstance(sync_channel_builder.src_process,
                                   RuntimeServiceBuilder):
@@ -221,10 +206,10 @@ class Runtime:
             self._is_running = True
             if isinstance(run_condition, RunSteps):
                 self.num_steps = run_condition.num_steps
-                for send_port in self.runtime_to_service_cmd:
+                for send_port in self.runtime_to_service:
                     send_port.send(enum_to_np(self.num_steps))
                 if run_condition.blocking:
-                    for recv_port in self.service_to_runtime_ack:
+                    for recv_port in self.service_to_runtime:
                         data = recv_port.recv()
                         if not enum_equal(data, MGMT_RESPONSE.DONE):
                             if enum_equal(data, MGMT_RESPONSE.ERROR):
@@ -255,7 +240,7 @@ class Runtime:
 
     def wait(self):
         if self._is_running:
-            for recv_port in self.service_to_runtime_ack:
+            for recv_port in self.service_to_runtime:
                 data = recv_port.recv()
                 if not enum_equal(data, MGMT_RESPONSE.DONE):
                     raise RuntimeError(f"Runtime Received {data}")
@@ -268,9 +253,9 @@ class Runtime:
         """Stops an ongoing or paused run."""
         try:
             if self._is_started:
-                for send_port in self.runtime_to_service_cmd:
+                for send_port in self.runtime_to_service:
                     send_port.send(MGMT_COMMAND.STOP)
-                for recv_port in self.service_to_runtime_ack:
+                for recv_port in self.service_to_runtime:
                     data = recv_port.recv()
                     if not enum_equal(data, MGMT_RESPONSE.TERMINATED):
                         raise RuntimeError(f"Runtime Received {data}")
@@ -285,15 +270,9 @@ class Runtime:
 
     def join(self):
         """Join all ports and processes"""
-        for port in self.runtime_to_service_cmd:
+        for port in self.runtime_to_service:
             port.join()
-        for port in self.service_to_runtime_ack:
-            port.join()
-        for port in self.runtime_to_service_req:
-            port.join()
-        for port in self.service_to_runtime_data:
-            port.join()
-        for port in self.runtime_to_service_data:
+        for port in self.service_to_runtime:
             port.join()
 
     def set_var(self, var_id: int, value: np.ndarray, idx: np.ndarray = None):
@@ -312,7 +291,7 @@ class Runtime:
             # from a model with model_id and var with var_id
 
             # 1. Send SET Command
-            req_port: CspSendPort = self.runtime_to_service_req[runtime_srv_id]
+            req_port: CspSendPort = self.runtime_to_service[runtime_srv_id]
             req_port.send(MGMT_COMMAND.SET_DATA)
             req_port.send(enum_to_np(model_id))
             req_port.send(enum_to_np(var_id))
@@ -326,8 +305,7 @@ class Runtime:
             buffer = buffer.reshape((1, num_items))
 
             # 3. Send [NUM_ITEMS, DATA1, DATA2, ...]
-            data_port: CspSendPort = self.runtime_to_service_data[
-                runtime_srv_id]
+            data_port: CspSendPort = self.runtime_to_service[runtime_srv_id]
             data_port.send(enum_to_np(num_items))
             for i in range(num_items):
                 data_port.send(enum_to_np(buffer[0, i], np.float64))
@@ -352,14 +330,13 @@ class Runtime:
             # from a model with model_id and var with var_id
 
             # 1. Send GET Command
-            req_port: CspSendPort = self.runtime_to_service_req[runtime_srv_id]
+            req_port: CspSendPort = self.runtime_to_service[runtime_srv_id]
             req_port.send(MGMT_COMMAND.GET_DATA)
             req_port.send(enum_to_np(model_id))
             req_port.send(enum_to_np(var_id))
 
             # 2. Receive Data [NUM_ITEMS, DATA1, DATA2, ...]
-            data_port: CspRecvPort = self.service_to_runtime_data[
-                runtime_srv_id]
+            data_port: CspRecvPort = self.service_to_runtime[runtime_srv_id]
             num_items: int = int(data_port.recv()[0].item())
             buffer: np.ndarray = np.empty((1, num_items))
             for i in range(num_items):

--- a/src/lava/magma/runtime/runtime_service.py
+++ b/src/lava/magma/runtime/runtime_service.py
@@ -23,11 +23,8 @@ class AbstractRuntimeService(ABC):
 
         self.runtime_service_id: ty.Optional[int] = None
 
-        self.runtime_to_service_cmd: ty.Optional[CspRecvPort] = None
-        self.service_to_runtime_ack: ty.Optional[CspSendPort] = None
-        self.runtime_to_service_req: ty.Optional[CspRecvPort] = None
-        self.service_to_runtime_data: ty.Optional[CspSendPort] = None
-        self.runtime_to_service_data: ty.Optional[CspRecvPort] = None
+        self.runtime_to_service: ty.Optional[CspRecvPort] = None
+        self.service_to_runtime: ty.Optional[CspSendPort] = None
 
         self.model_ids: ty.List[int] = []
 
@@ -40,11 +37,8 @@ class AbstractRuntimeService(ABC):
                  Protocol: {self.protocol}"
 
     def start(self):
-        self.runtime_to_service_cmd.start()
-        self.service_to_runtime_ack.start()
-        self.runtime_to_service_req.start()
-        self.service_to_runtime_data.start()
-        self.runtime_to_service_data.start()
+        self.runtime_to_service.start()
+        self.service_to_runtime.start()
         for i in range(len(self.service_to_process)):
             self.service_to_process[i].start()
             self.process_to_service[i].start()
@@ -55,11 +49,8 @@ class AbstractRuntimeService(ABC):
         pass
 
     def join(self):
-        self.runtime_to_service_cmd.join()
-        self.service_to_runtime_ack.join()
-        self.runtime_to_service_req.join()
-        self.service_to_runtime_data.join()
-        self.runtime_to_service_data.join()
+        self.runtime_to_service.join()
+        self.service_to_runtime.join()
 
         for i in range(len(self.service_to_process)):
             self.service_to_process[i].join()
@@ -130,9 +121,9 @@ class LoihiPyRuntimeService(PyRuntimeService):
     def _relay_to_runtime_data_given_model_id(self, model_id: int):
         """Relays data received from ProcessModel given by model id  to the
         runtime"""
-        process_idx = self.model_ids.index(int(model_id))
+        process_idx = self.model_ids.index(model_id)
         data_recv_port = self.process_to_service[process_idx]
-        data_relay_port = self.service_to_runtime_data
+        data_relay_port = self.service_to_runtime
         num_items = data_recv_port.recv()
         data_relay_port.send(num_items)
         for i in range(int(num_items[0])):
@@ -144,7 +135,7 @@ class LoihiPyRuntimeService(PyRuntimeService):
         the model id."""
         process_idx = self.model_ids.index(model_id)
 
-        data_recv_port = self.runtime_to_service_data
+        data_recv_port = self.runtime_to_service
         data_relay_port = self.service_to_process[process_idx]
         # Receive and relay number of items
         num_items = data_recv_port.recv()
@@ -159,7 +150,7 @@ class LoihiPyRuntimeService(PyRuntimeService):
         process_idx = self.model_ids.index(model_id)
 
         ack_recv_port = self.process_to_service[process_idx]
-        ack_relay_port = self.service_to_runtime_ack
+        ack_relay_port = self.service_to_runtime
         ack_relay_port.send(ack_recv_port.recv())
 
     def run(self):
@@ -171,12 +162,15 @@ class LoihiPyRuntimeService(PyRuntimeService):
         step. The loop ends when receiving the STOP command from the runtime."""
         selector = CspSelector()
         phase = LoihiPyRuntimeService.Phase.HOST
+
+        channel_actions = [(self.runtime_to_service, lambda: 'cmd')]
+
         while True:
             # Probe if there is a new command from the runtime
-            cmd = selector.select((self.runtime_to_service_cmd, lambda: True),
-                                  (self.runtime_to_service_req, lambda: False))
-            if cmd:
-                command = self.runtime_to_service_cmd.recv()
+            action = selector.select(*channel_actions)
+
+            if action == 'cmd':
+                command = self.runtime_to_service.recv()
                 if enum_equal(command, MGMT_COMMAND.STOP):
                     # Inform all ProcessModels about the STOP command
                     self._send_pm_cmd(command)
@@ -185,7 +179,7 @@ class LoihiPyRuntimeService(PyRuntimeService):
                         if not enum_equal(rsp, MGMT_RESPONSE.TERMINATED):
                             raise ValueError(f"Wrong Response Received : {rsp}")
                     # Inform the runtime about successful termination
-                    self.service_to_runtime_ack.send(MGMT_RESPONSE.TERMINATED)
+                    self.service_to_runtime.send(MGMT_RESPONSE.TERMINATED)
                     self.join()
                     return
                 elif enum_equal(command, MGMT_COMMAND.PAUSE):
@@ -196,8 +190,11 @@ class LoihiPyRuntimeService(PyRuntimeService):
                         if not enum_equal(rsp, MGMT_RESPONSE.PAUSED):
                             raise ValueError(f"Wrong Response Received : {rsp}")
                     # Inform the runtime about successful pausing
-                    self.service_to_runtime_ack.send(MGMT_RESPONSE.PAUSED)
+                    self.service_to_runtime.send(MGMT_RESPONSE.PAUSED)
                     break
+                elif enum_equal(command, MGMT_COMMAND.GET_DATA) or \
+                        enum_equal(command, MGMT_COMMAND.SET_DATA):
+                    self._handle_get_set(phase, command)
                 else:
                     # The number of time steps was received ("command")
                     # Start iterating through Loihi phases
@@ -222,7 +219,7 @@ class LoihiPyRuntimeService(PyRuntimeService):
                                 if not enum_equal(rsp, MGMT_RESPONSE.DONE):
                                     if enum_equal(rsp, MGMT_RESPONSE.ERROR):
                                         # Forward error to runtime
-                                        self.service_to_runtime_ack.send(
+                                        self.service_to_runtime.send(
                                             MGMT_RESPONSE.ERROR)
                                         # stop all other pm
                                         self._send_pm_cmd(MGMT_COMMAND.STOP)
@@ -237,45 +234,28 @@ class LoihiPyRuntimeService(PyRuntimeService):
                             break
 
                     # Inform the runtime that last time step was reached
-                    self.service_to_runtime_ack.send(MGMT_RESPONSE.DONE)
-            else:
-                # Handle get/set Var
-                self._handle_get_set(phase)
+                    self.service_to_runtime.send(MGMT_RESPONSE.DONE)
 
-    def _handle_get_set(self, phase):
+    def _handle_get_set(self, phase, command):
         if enum_equal(phase, LoihiPyRuntimeService.Phase.HOST):
-            request = self.runtime_to_service_req.recv()
-            if enum_equal(request, MGMT_COMMAND.GET_DATA):
-                requests: ty.List[np.ndarray] = [request]
+            if enum_equal(command, MGMT_COMMAND.GET_DATA):
+                requests: ty.List[np.ndarray] = [command]
                 # recv model_id
-                model_id: int = \
-                    self.runtime_to_service_req.recv()[
-                        0].item()
+                model_id: int = int(self.runtime_to_service.recv()[0].item())
                 # recv var_id
-                requests.append(
-                    self.runtime_to_service_req.recv())
-                self._send_pm_req_given_model_id(model_id,
-                                                 *requests)
-
-                self._relay_to_runtime_data_given_model_id(
-                    model_id)
-            elif enum_equal(request, MGMT_COMMAND.SET_DATA):
-                requests: ty.List[np.ndarray] = [request]
+                requests.append(self.runtime_to_service.recv())
+                self._send_pm_req_given_model_id(model_id, *requests)
+                self._relay_to_runtime_data_given_model_id(model_id)
+            elif enum_equal(command, MGMT_COMMAND.SET_DATA):
+                requests: ty.List[np.ndarray] = [command]
                 # recv model_id
-                model_id: int = \
-                    self.runtime_to_service_req.recv()[
-                        0].item()
+                model_id: int = int(self.runtime_to_service.recv()[0].item())
                 # recv var_id
-                requests.append(
-                    self.runtime_to_service_req.recv())
-                self._send_pm_req_given_model_id(model_id,
-                                                 *requests)
-
-                self._relay_to_pm_data_given_model_id(
-                    model_id)
+                requests.append(self.runtime_to_service.recv())
+                self._send_pm_req_given_model_id(model_id, *requests)
+                self._relay_to_pm_data_given_model_id(model_id)
             else:
-                raise RuntimeError(
-                    f"Unknown request {request}")
+                raise RuntimeError(f"Unknown request {command}")
 
 
 class LoihiCRuntimeService(AbstractRuntimeService):
@@ -298,14 +278,14 @@ class AsyncPyRuntimeService(PyRuntimeService):
 
     def run(self):
         while True:
-            command = self.runtime_to_service_cmd.recv()
+            command = self.runtime_to_service.recv()
             if enum_equal(command, MGMT_COMMAND.STOP):
                 self._send_pm_cmd(command)
                 rsps = self._get_pm_resp()
                 for rsp in rsps:
                     if not enum_equal(rsp, MGMT_RESPONSE.TERMINATED):
                         raise ValueError(f"Wrong Response Received : {rsp}")
-                self.service_to_runtime_ack.send(MGMT_RESPONSE.TERMINATED)
+                self.service_to_runtime.send(MGMT_RESPONSE.TERMINATED)
                 self.join()
                 return
             else:
@@ -314,4 +294,4 @@ class AsyncPyRuntimeService(PyRuntimeService):
                 for rsp in rsps:
                     if not enum_equal(rsp, MGMT_RESPONSE.DONE):
                         raise ValueError(f"Wrong Response Received : {rsp}")
-                self.service_to_runtime_ack.send(MGMT_RESPONSE.DONE)
+                self.service_to_runtime.send(MGMT_RESPONSE.DONE)

--- a/tests/lava/magma/runtime/test_get_set_var.py
+++ b/tests/lava/magma/runtime/test_get_set_var.py
@@ -92,7 +92,6 @@ class TestGetSetVar(unittest.TestCase):
                               expected_result_u)
         assert np.array_equal(process._runtime.get_var(process.v.id),
                               expected_result_v)
-        self.assertEqual(process.runtime.global_time, 15)
         process.stop()
 
     def test_get_set_var_using_var_api(self):
@@ -129,7 +128,6 @@ class TestGetSetVar(unittest.TestCase):
         process.run(condition=RunSteps(num_steps=5), run_cfg=run_config)
         assert np.array_equal(process.u.get(), expected_result_u)
         assert np.array_equal(process.v.get(), expected_result_v)
-        self.assertEqual(process.runtime.global_time, 15)
         process.stop()
 
 

--- a/tests/lava/magma/runtime/test_loihi_protocol.py
+++ b/tests/lava/magma/runtime/test_loihi_protocol.py
@@ -59,7 +59,6 @@ class TestProcess(unittest.TestCase):
         run_config = SimpleRunConfig(sync_domains=[simple_sync_domain])
         process.run(condition=RunSteps(num_steps=10), run_cfg=run_config)
         process.run(condition=RunSteps(num_steps=5), run_cfg=run_config)
-        self.assertEqual(process.runtime.global_time, 15)
         process.stop()
 
 

--- a/tests/lava/magma/runtime/test_runtime.py
+++ b/tests/lava/magma/runtime/test_runtime.py
@@ -4,7 +4,6 @@ import unittest
 from lava.magma.compiler.executable import Executable
 from lava.magma.core.process.message_interface_enum import ActorType
 from lava.magma.core.resources import HeadNode
-from lava.magma.core.run_conditions import RunSteps, AbstractRunCondition
 from lava.magma.compiler.node import Node, NodeConfig
 from lava.magma.runtime.runtime import Runtime
 

--- a/tests/lava/magma/runtime/test_runtime.py
+++ b/tests/lava/magma/runtime/test_runtime.py
@@ -13,10 +13,8 @@ class TestRuntime(unittest.TestCase):
     def test_runtime_creation(self):
         """Tests runtime constructor"""
         exe: Executable = Executable()
-        run_cond: AbstractRunCondition = RunSteps(num_steps=10)
         mp = ActorType.MultiProcessing
-        runtime: Runtime = Runtime(
-                                   exe=exe,
+        runtime: Runtime = Runtime(exe=exe,
                                    message_infrastructure_type=mp)
         expected_type: ty.Type = Runtime
         assert isinstance(
@@ -26,7 +24,6 @@ class TestRuntime(unittest.TestCase):
     def test_executable_node_config_assertion(self):
         """Tests runtime constructions with expected constraints"""
         exec: Executable = Executable()
-        run_cond: AbstractRunCondition = RunSteps(num_steps=10)
 
         runtime1: Runtime = Runtime(exec, ActorType.MultiProcessing)
         with self.assertRaises(AssertionError):

--- a/tests/lava/magma/runtime/test_runtime.py
+++ b/tests/lava/magma/runtime/test_runtime.py
@@ -15,7 +15,7 @@ class TestRuntime(unittest.TestCase):
         exe: Executable = Executable()
         run_cond: AbstractRunCondition = RunSteps(num_steps=10)
         mp = ActorType.MultiProcessing
-        runtime: Runtime = Runtime(run_cond=run_cond,
+        runtime: Runtime = Runtime(
                                    exe=exe,
                                    message_infrastructure_type=mp)
         expected_type: ty.Type = Runtime
@@ -28,13 +28,13 @@ class TestRuntime(unittest.TestCase):
         exec: Executable = Executable()
         run_cond: AbstractRunCondition = RunSteps(num_steps=10)
 
-        runtime1: Runtime = Runtime(run_cond, exec, ActorType.MultiProcessing)
+        runtime1: Runtime = Runtime(exec, ActorType.MultiProcessing)
         with self.assertRaises(AssertionError):
             runtime1.initialize()
 
         node: Node = Node(HeadNode, [])
         exec.node_configs.append(NodeConfig([node]))
-        runtime2: Runtime = Runtime(run_cond, exec, ActorType.MultiProcessing)
+        runtime2: Runtime = Runtime(exec, ActorType.MultiProcessing)
         runtime2.initialize()
         expected_type: ty.Type = Runtime
         assert isinstance(
@@ -43,12 +43,12 @@ class TestRuntime(unittest.TestCase):
         runtime2.stop()
 
         exec.node_configs[0].append(node)
-        runtime3: Runtime = Runtime(run_cond, exec, ActorType.MultiProcessing)
+        runtime3: Runtime = Runtime(exec, ActorType.MultiProcessing)
         with self.assertRaises(AssertionError):
             runtime3.initialize()
 
         exec.node_configs.append(NodeConfig([node]))
-        runtime4: Runtime = Runtime(run_cond, exec, ActorType.MultiProcessing)
+        runtime4: Runtime = Runtime(exec, ActorType.MultiProcessing)
         with self.assertRaises(AssertionError):
             runtime4.initialize()
 

--- a/tests/lava/magma/runtime/test_runtime_service.py
+++ b/tests/lava/magma/runtime/test_runtime_service.py
@@ -52,12 +52,9 @@ class TestRuntimeService(unittest.TestCase):
         sp = SimpleSyncProtocol()
         rs = SimplePyRuntimeService(protocol=sp)
         self.assertEqual(rs.protocol, sp)
-        self.assertEqual(rs.service_to_runtime_ack, None)
-        self.assertEqual(rs.service_to_runtime_data, None)
+        self.assertEqual(rs.service_to_runtime, None)
         self.assertEqual(rs.service_to_process, [])
-        self.assertEqual(rs.runtime_to_service_cmd, None)
-        self.assertEqual(rs.runtime_to_service_req, None)
-        self.assertEqual(rs.runtime_to_service_data, None)
+        self.assertEqual(rs.runtime_to_service, None)
         self.assertEqual(rs.process_to_service, [])
 
     def test_runtime_service_start_run(self):
@@ -66,35 +63,19 @@ class TestRuntimeService(unittest.TestCase):
         rs = SimplePyRuntimeService(protocol=sp)
         smm = SharedMemoryManager()
         smm.start()
-        runtime_to_service_cmd = create_channel(smm,
-                                                name="runtime_to_service_cmd")
-        service_to_runtime_ack = create_channel(smm,
-                                                name="service_to_runtime_ack")
-        runtime_to_service_req = create_channel(smm,
-                                                name="runtime_to_service_req")
-        service_to_runtime_data = create_channel(smm,
-                                                 name="service_to_runtime_data")
-        runtime_to_service_data = create_channel(smm,
-                                                 name="runtime_to_service_data")
-        service_to_process = [
-            create_channel(smm, name="service_to_process")]
-        process_to_service = [
-            create_channel(smm, name="process_to_service_ack")]
-        runtime_to_service_cmd.dst_port.start()
-        service_to_runtime_ack.src_port.start()
-        runtime_to_service_req.src_port.start()
-        service_to_runtime_data.dst_port.start()
-        runtime_to_service_data.src_port.start()
+        runtime_to_service = create_channel(smm, name="runtime_to_service")
+        service_to_runtime = create_channel(smm, name="service_to_runtime")
+        service_to_process = [create_channel(smm, name="service_to_process")]
+        process_to_service = [create_channel(smm, name="process_to_service")]
+        runtime_to_service.dst_port.start()
+        service_to_runtime.src_port.start()
 
         pm.service_to_process = service_to_process[0].dst_port
         pm.process_to_service = process_to_service[0].src_port
         pm.py_ports = []
         pm.start()
-        rs.runtime_to_service_cmd = runtime_to_service_cmd.src_port
-        rs.service_to_runtime_ack = service_to_runtime_ack.dst_port
-        rs.service_to_runtime_data = service_to_runtime_data.dst_port
-        rs.runtime_to_service_req = runtime_to_service_req.src_port
-        rs.runtime_to_service_data = runtime_to_service_data.dst_port
+        rs.runtime_to_service = runtime_to_service.src_port
+        rs.service_to_runtime = service_to_runtime.dst_port
         rs.service_to_process = [service_to_process[0].src_port]
         rs.process_to_service = [process_to_service[0].dst_port]
         rs.join()

--- a/tests/lava/magma/runtime/test_runtime_service.py
+++ b/tests/lava/magma/runtime/test_runtime_service.py
@@ -54,14 +54,11 @@ class TestRuntimeService(unittest.TestCase):
         self.assertEqual(rs.protocol, sp)
         self.assertEqual(rs.service_to_runtime_ack, None)
         self.assertEqual(rs.service_to_runtime_data, None)
-        self.assertEqual(rs.service_to_process_cmd, [])
-        self.assertEqual(rs.service_to_process_req, [])
-        self.assertEqual(rs.service_to_process_data, [])
+        self.assertEqual(rs.service_to_process, [])
         self.assertEqual(rs.runtime_to_service_cmd, None)
         self.assertEqual(rs.runtime_to_service_req, None)
         self.assertEqual(rs.runtime_to_service_data, None)
-        self.assertEqual(rs.process_to_service_ack, [])
-        self.assertEqual(rs.process_to_service_data, [])
+        self.assertEqual(rs.process_to_service, [])
 
     def test_runtime_service_start_run(self):
         pm = SimpleProcessModel()
@@ -79,27 +76,18 @@ class TestRuntimeService(unittest.TestCase):
                                                  name="service_to_runtime_data")
         runtime_to_service_data = create_channel(smm,
                                                  name="runtime_to_service_data")
-        service_to_process_cmd = [
-            create_channel(smm, name="service_to_process_cmd")]
-        process_to_service_ack = [
+        service_to_process = [
+            create_channel(smm, name="service_to_process")]
+        process_to_service = [
             create_channel(smm, name="process_to_service_ack")]
-        service_to_process_req = [
-            create_channel(smm, name="service_to_process_req")]
-        process_to_service_data = [
-            create_channel(smm, name="process_to_service_data")]
-        service_to_process_data = [
-            create_channel(smm, name="service_to_process_data")]
         runtime_to_service_cmd.dst_port.start()
         service_to_runtime_ack.src_port.start()
         runtime_to_service_req.src_port.start()
         service_to_runtime_data.dst_port.start()
         runtime_to_service_data.src_port.start()
 
-        pm.service_to_process_cmd = service_to_process_cmd[0].dst_port
-        pm.service_to_process_req = service_to_process_req[0].dst_port
-        pm.service_to_process_data = service_to_process_data[0].dst_port
-        pm.process_to_service_ack = process_to_service_ack[0].src_port
-        pm.process_to_service_data = process_to_service_data[0].src_port
+        pm.service_to_process = service_to_process[0].dst_port
+        pm.process_to_service = process_to_service[0].src_port
         pm.py_ports = []
         pm.start()
         rs.runtime_to_service_cmd = runtime_to_service_cmd.src_port
@@ -107,11 +95,8 @@ class TestRuntimeService(unittest.TestCase):
         rs.service_to_runtime_data = service_to_runtime_data.dst_port
         rs.runtime_to_service_req = runtime_to_service_req.src_port
         rs.runtime_to_service_data = runtime_to_service_data.dst_port
-        rs.service_to_process_cmd = [service_to_process_cmd[0].src_port]
-        rs.process_to_service_ack = [process_to_service_ack[0].dst_port]
-        rs.service_to_process_req = [service_to_process_req[0].src_port]
-        rs.process_to_service_data = [process_to_service_data[0].dst_port]
-        rs.service_to_process_data = [service_to_process_data[0].src_port]
+        rs.service_to_process = [service_to_process[0].src_port]
+        rs.process_to_service = [process_to_service[0].dst_port]
         rs.join()
         pm.join()
         smm.shutdown()


### PR DESCRIPTION
* Reduced the number of channels between service and process

* Fixed the bug with failing monitor cases

<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: Remove hacks and refactor Runtime and RuntimeService/Synchronizer #86

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: Reduced the number of channels between service and process

## Pull request checklist

Your PR fulfills the following requirements:
- [X ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [X ] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [X] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [ ] Lint (`pyb`) passes locally
- [x] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- Currently we have five channels between runtime service and process model. 
- 1. Used for sending cmd from RS to PM
- 2. Used for sending ack back from PM to RS
- 3. Used for sending READ/WRITE Req from RS to PM
- 4. Used to send write data from RS to PM
- 5. Used to send read data from PM to RS

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- Reduces the number of channels between runtime service and process model. Also it removes the notion of time step from the runtime.
- 1. One way channel for all cmd/get-set-req/data from RS to PM
- 2. One channel for all ack/data from PM to RS

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
