### PR TITLE
Proc_params for communicating arbitrary object between process and process model

### DIFF
--- a/src/lava/magma/compiler/builder.py
+++ b/src/lava/magma/compiler/builder.py
@@ -356,16 +356,7 @@ class PyProcessBuilder(AbstractProcessBuilder):
         # Default value of pm.proc_params in ProcessModel is an empty dictionary
         # If a proc_params argument is provided in PyProcessBuilder,
         # this will be carried to ProcessModel
-        if self.proc_params:
-            pm = self.proc_model(self.proc_params)
-        else:
-            # Calling base class constructor directly where proc_params is
-            # initialized to a default value of {} which is the desired
-            # behavior.
-            # This enables backward compatibility with some existing processes
-            # where __init__ is overloaded without proc_params argument.
-            # Without this, the execution hangs for such processes.
-            pm = self.proc_model()
+        pm = self.proc_model(self.proc_params)
         pm.model_id = self._model_id
 
         # Initialize PyPorts

--- a/src/lava/magma/compiler/builder.py
+++ b/src/lava/magma/compiler/builder.py
@@ -359,11 +359,12 @@ class PyProcessBuilder(AbstractProcessBuilder):
         if self.proc_params:
             pm = self.proc_model(self.proc_params)
         else:
-            # Empty argument because some existing process models where __init__
-            # is overloaded without proc_model argument, the execution hangs.
-            # However, when the base class constructor is called, proc_model
-            # is initialized to a default value of {} which is the desired
+            # Calling base class constructor directly where proc_params is
+            # initialized to a default value of {} which is the desired
             # behavior.
+            # This enables backward compatibility with some existing processes
+            # where __init__ is overloaded without proc_params argument.
+            # Without this, the execution hangs for such processes.
             pm = self.proc_model()
         pm.model_id = self._model_id
 

--- a/src/lava/magma/compiler/builder.py
+++ b/src/lava/magma/compiler/builder.py
@@ -354,14 +354,19 @@ class PyProcessBuilder(AbstractProcessBuilder):
         """
 
         # Create the ProcessModel
-        pm = self.proc_model()
-        pm.model_id = self._model_id
-
         # Default value of pm.proc_params in ProcessModel is an empty dictionary
         # If a proc_params argument is provided in PyProcessBuilder,
         # this will be carried to ProcessModel
-        if self.proc_params is not None:
-            pm.proc_params = self.proc_params
+        if self.proc_params:
+            pm = self.proc_model(self.proc_params)
+        else:
+            # Empty argument because some existing process models where __init__
+            # is overloaded without proc_model argument, the execution hangs.
+            # However, when the base class constructor is called, proc_model
+            # is initialized to a default value of {} which is the desired
+            # behavior.
+            pm = self.proc_model()
+        pm.model_id = self._model_id
 
         # Initialize PyPorts
         for name, p in self.py_ports.items():

--- a/src/lava/magma/core/model/model.py
+++ b/src/lava/magma/core/model/model.py
@@ -52,6 +52,9 @@ class AbstractProcessModel(ABC):
     required_resources: ty.List[ty.Type[AbstractResource]] = []
     tags: ty.List[str] = []
 
+    def __init__(self, proc_params: ty.Dict[str, ty.Any]) -> None:
+        self.proc_params: ty.Dict[str, ty.Any] = proc_params
+
     def __repr__(self):
         pm_name = self.__class__.__qualname__
         p_name = self.implements_process.__qualname__

--- a/src/lava/magma/core/model/model.py
+++ b/src/lava/magma/core/model/model.py
@@ -45,6 +45,10 @@ class AbstractProcessModel(ABC):
     although this leads to a bit of verbosity in the end. We could leave out
     the class type in the LavaType and infer it from
     ProcModel.__annotations__ if the user has not forgotten to specify it.
+    3. Process can communicate arbitrary objects using it's ``proc_params``
+    member. This should be used when such a need arises. A Process's
+    ``proc_prams`` (empty dictionary by default) should always be used to
+    initialize it's ProcessModel.
     """
 
     implements_process: ty.Optional[ty.Type[AbstractProcess]] = None

--- a/src/lava/magma/core/model/py/model.py
+++ b/src/lava/magma/core/model/py/model.py
@@ -29,15 +29,14 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
         du: int =          LavaPyType(int, np.uint16, precision=12)
     """
 
-    def __init__(self, proc_params: ty.Dict[str, ty.Any] = {}):
-        super().__init__()
+    def __init__(self, proc_params: ty.Dict[str, ty.Any]) -> None:
+        super().__init__(proc_params)
         self.model_id: ty.Optional[int] = None
         self.service_to_process: ty.Optional[CspRecvPort] = None
         self.process_to_service: ty.Optional[CspSendPort] = None
         self.py_ports: ty.List[AbstractPyPort] = []
         self.var_ports: ty.List[PyVarPort] = []
         self.var_id_to_var_map: ty.Dict[int, ty.Any] = {}
-        self.proc_params: ty.Dict[str, ty.Any] = proc_params
 
     def __setattr__(self, key: str, value: ty.Any):
         self.__dict__[key] = value
@@ -66,7 +65,7 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
 
 
 class PyLoihiProcessModel(AbstractPyProcessModel):
-    def __init__(self, proc_params: ty.Dict[str, ty.Any] = {}):
+    def __init__(self, proc_params: ty.Dict[str, ty.Any]):
         super(PyLoihiProcessModel, self).__init__(proc_params)
         self.current_ts = 0
 

--- a/src/lava/magma/core/model/py/model.py
+++ b/src/lava/magma/core/model/py/model.py
@@ -30,7 +30,7 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
         du: int =          LavaPyType(int, np.uint16, precision=12)
     """
 
-    def __init__(self):
+    def __init__(self, proc_params: ty.Dict[str, ty.Any] = {}):
         super().__init__()
         self.model_id: ty.Optional[int] = None
         self.service_to_process_cmd: ty.Optional[CspRecvPort] = None
@@ -41,7 +41,7 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
         self.py_ports: ty.List[AbstractPyPort] = []
         self.var_ports: ty.List[PyVarPort] = []
         self.var_id_to_var_map: ty.Dict[int, ty.Any] = {}
-        self.proc_params: ty.Dict[str, ty.Any] = {}
+        self.proc_params: ty.Dict[str, ty.Any] = proc_params
 
     def __setattr__(self, key: str, value: ty.Any):
         self.__dict__[key] = value
@@ -76,8 +76,8 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
 
 
 class PyLoihiProcessModel(AbstractPyProcessModel):
-    def __init__(self):
-        super(PyLoihiProcessModel, self).__init__()
+    def __init__(self, proc_params: ty.Dict[str, ty.Any] = {}):
+        super(PyLoihiProcessModel, self).__init__(proc_params)
         self.current_ts = 0
 
     class Phase:

--- a/src/lava/magma/core/process/process.py
+++ b/src/lava/magma/core/process/process.py
@@ -181,7 +181,10 @@ class AbstractProcess(metaclass=ProcessPostInitCaller):
     ```
     Processes do only specify their states, ports and other public interface
     methods but they do not specify the behavior. Instead, ProcessModels
-    specify which Processes they implement.
+    specify which Processes they implement. Typically, Processes share their
+    states, ports and other public interface methods with their ProcessModels.
+    For special cases, one can use proc_params memeber of the process to
+    communicate arbitrary object between Processes and their PorcessModels.
     For more information on connecting process, see documentation of InPort,
     OutPort and RefPort.
 

--- a/src/lava/magma/core/resources.py
+++ b/src/lava/magma/core/resources.py
@@ -17,6 +17,10 @@ class CPU(AbstractComputeResource):
     pass
 
 
+class HostCPU(AbstractComputeResource):
+    pass
+
+
 class GPU(AbstractComputeResource):
     pass
 

--- a/src/lava/proc/dense/models.py
+++ b/src/lava/proc/dense/models.py
@@ -60,8 +60,8 @@ class PyDenseModelBitAcc(PyLoihiProcessModel):
     num_weight_bits: np.ndarray = LavaPyType(np.ndarray, np.int32, precision=3)
     sign_mode: np.ndarray = LavaPyType(np.ndarray, np.int32, precision=2)
 
-    def __init__(self):
-        super(PyDenseModelBitAcc, self).__init__()
+    def __init__(self, proc_params):
+        super(PyDenseModelBitAcc, self).__init__(proc_params)
         # Flag to determine whether weights have already been scaled.
         self.weights_set = False
 

--- a/src/lava/proc/io/dataloader.py
+++ b/src/lava/proc/io/dataloader.py
@@ -106,7 +106,7 @@ class StateDataloader(AbstractDataloader):
         self._post_init()
 
 
-class AbstractPyStateModel(AbstractPyDataloaderModel):
+class AbstractPyStateDataloaderModel(AbstractPyDataloaderModel):
     state: Union[PyRefPort, None] = None
 
     def run_spk(self) -> None:
@@ -126,13 +126,13 @@ class AbstractPyStateModel(AbstractPyDataloaderModel):
 
 @implements(proc=StateDataloader, protocol=LoihiProtocol)
 @tag('fixed_pt')
-class PyStateModelFixed(AbstractPyStateModel):
+class PyStateModelFixed(AbstractPyStateDataloaderModel):
     state: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, np.int32)
 
 
 @implements(proc=StateDataloader, protocol=LoihiProtocol)
 @tag('floating_pt')
-class PyStateModelFloat(AbstractPyStateModel):
+class PyStateModelFloat(AbstractPyStateDataloaderModel):
     state: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, float)
 
 
@@ -167,7 +167,7 @@ class SpikeDataloader(AbstractDataloader):
         self.s_out = OutPort(shape=data.shape[:-1])  # last dimension is time
 
 
-class AbstractPySpikeModel(AbstractPyDataloaderModel):
+class AbstractPySpikeDataloaderModel(AbstractPyDataloaderModel):
     s_out: Union[PyOutPort, None] = None
     data: Union[np.ndarray, None] = None
 
@@ -199,13 +199,13 @@ class AbstractPySpikeModel(AbstractPyDataloaderModel):
 
 @implements(proc=SpikeDataloader, protocol=LoihiProtocol)
 @tag('fixed_pt')
-class PySpikeModelFixed(AbstractPySpikeModel):
+class PySpikeModelFixed(AbstractPySpikeDataloaderModel):
     s_out: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, np.int32)
     data: np.ndarray = LavaPyType(np.ndarray, np.int32)
 
 
 @implements(proc=SpikeDataloader, protocol=LoihiProtocol)
 @tag('floating_pt')
-class PySpikeModelFloat(AbstractPySpikeModel):
+class PySpikeModelFloat(AbstractPySpikeDataloaderModel):
     s_out: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, float)
     data: np.ndarray = LavaPyType(np.ndarray, float)

--- a/src/lava/proc/io/dataloader.py
+++ b/src/lava/proc/io/dataloader.py
@@ -1,0 +1,193 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+# See: https://spdx.org/licenses/
+
+from typing import Iterable, Union
+import numpy as np
+
+from lava.magma.core.process.process import AbstractProcess
+from lava.magma.core.process.ports.ports import OutPort, RefPort
+from lava.magma.core.process.variable import Var
+from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
+from lava.magma.core.model.py.ports import PyOutPort, PyRefPort
+from lava.magma.core.model.py.type import LavaPyType
+from lava.magma.core.resources import HostCPU
+from lava.magma.core.decorator import implements, requires, tag
+from lava.magma.core.model.py.model import PyLoihiProcessModel
+
+
+# State dataloader ###########################################################
+class State(AbstractProcess):
+    """Dataloader object that loads new data sample to internal state at a
+    set interval and offset (phase).
+
+    Parameters
+    ----------
+    dataset : Iterable
+        The actual dataset object. Dataset is expected to return
+        ``(input, label/ground_truth)`` when indexed.
+    interval : int, optional
+        Interval between each data load, by default 1
+    offset : int, optional
+        Offset (phase) for each data load, by default 0
+    """
+    def __init__(
+        self,
+        dataset: Iterable,
+        interval: int = 1,
+        offset: int = 0,
+    ) -> None:
+        super().__init__()
+        self.interval = Var((1,), interval)
+        self.offset = Var((1,), offset % interval)
+        data, gt = dataset[0]
+        self.state = RefPort(data.shape)
+        self.gt = OutPort((1,) if np.isscalar(gt) else gt.shape)
+        self.proc_params['saved_dataset'] = dataset
+
+    def connect_var(self, var: Var) -> None:
+        """Connects the internal state (ref-port) to the variable. The variable
+        can be internal state of some other process which needs to reflect the
+        dataset input.
+
+        Parameters
+        ----------
+        var : Var
+            Variable that is connected to this object's state (ref-port).
+        """
+        self.state = RefPort(var.shape)
+        self.state.connect_var(var)
+        self._post_init()
+
+
+@requires(HostCPU)
+class AbstractPyStateModel(PyLoihiProcessModel):
+    state: Union[PyRefPort, None] = None
+    gt: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, float)
+    interval: np.ndarray = LavaPyType(np.ndarray, int)
+    offset: np.ndarray = LavaPyType(np.ndarray, int)
+
+    def __init__(self, proc_params: dict) -> None:
+        super().__init__(proc_params)
+        self.sample_id = 0
+        self.gt_state = 0
+        self.dataset = self.proc_params['saved_dataset']
+
+    def gt_array(self) -> np.ndarray:
+        if np.isscalar(self.gt_state):
+            return np.array([self.gt_state])
+        return self.gt_state
+
+    def run_spk(self) -> None:
+        self.gt.send(self.gt_array())
+
+    def post_guard(self) -> None:
+        return (self.current_ts - 1) % self.interval == self.offset
+
+    def run_post_mgmt(self) -> None:
+        data, self.gt_state = self.dataset[self.sample_id]
+        self.gt_state = self.gt_array()
+        self.state.write(data)
+        self.sample_id += 1
+        if self.sample_id == len(self.dataset):
+            self.sample_id = 0
+
+
+@implements(proc=State, protocol=LoihiProtocol)
+@tag('fixed_pt')
+class PyStateModelFixed(AbstractPyStateModel):
+    state: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, np.int32)
+
+
+@implements(proc=State, protocol=LoihiProtocol)
+@tag('floating_pt')
+class PyStateModelFloat(AbstractPyStateModel):
+    state: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, float)
+
+
+# Spike Dataloader ############################################################
+class Spike(AbstractProcess):
+    """Dataloader object that sends spike for a input sample at a
+    set interval and offset (phase).
+
+    Parameters
+    ----------
+    dataset : Iterable
+        The actual dataset object. Dataset is expected to return
+        ``(spike, label/ground_truth)`` when indexed.
+    interval : int, optional
+        Interval between each data load, by default 1
+    offset : int, optional
+        Offset (phase) for each data load, by default 0
+    """
+    def __init__(
+        self,
+        dataset: Iterable,
+        interval: int = 1,
+        offset: int = 0,
+    ) -> None:
+        super().__init__()
+        self.interval = Var((1,), interval)
+        self.offset = Var((1,), offset % interval)
+        data, gt = dataset[0]
+        data_shape = data.shape[:-1] + (interval,)
+        self.data = Var(shape=data_shape, init=np.zeros(data_shape))
+        self.s_out = OutPort(shape=data.shape[:-1])  # last dimension is time
+        self.gt = OutPort(shape=(1,) if np.isscalar(gt) else gt.shape)
+        self.proc_params['saved_dataset'] = dataset
+
+
+@requires(HostCPU)
+class AbstractPySpikeModel(PyLoihiProcessModel):
+    s_out: Union[PyOutPort, None] = None
+    gt: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, float)
+    data: Union[np.ndarray, None] = None
+    interval: np.ndarray = LavaPyType(np.ndarray, int)
+    offset: np.ndarray = LavaPyType(np.ndarray, int)
+
+    def __init__(self, proc_params: dict) -> None:
+        super().__init__(proc_params)
+        self.sample_id = 0
+        self.sample_time = 0
+        self.gt_state = 0
+        self.dataset = self.proc_params['saved_dataset']
+
+    def gt_array(self) -> np.ndarray:
+        if np.isscalar(self.gt_state):
+            return np.array([self.gt_state])
+        return self.gt_state
+
+    def run_spk(self) -> None:
+        self.s_out.send(self.data[..., self.sample_time % self.interval.item()])
+        self.gt.send(self.gt_array())
+        self.sample_time += 1
+
+    def post_guard(self) -> None:
+        return (self.current_ts - 1) % self.interval == self.offset
+
+    def run_post_mgmt(self) -> None:
+        data, self.gt_state = self.dataset[self.sample_id]
+        self.gt_state = self.gt_array()
+        if data.shape[-1] >= self.interval:
+            self.data = data[..., :self.interval.item()]
+        else:
+            self.data = np.zeros_like(self.data)
+            self.data[..., :data.shape[-1]] = data
+        self.sample_time = 0
+        self.sample_id += 1
+        if self.sample_id == len(self.dataset):
+            self.sample_id = 0
+
+
+@implements(proc=Spike, protocol=LoihiProtocol)
+@tag('fixed_pt')
+class PySpikeModelFixed(AbstractPySpikeModel):
+    s_out: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, np.int32)
+    data: np.ndarray = LavaPyType(np.ndarray, np.int32)
+
+
+@implements(proc=Spike, protocol=LoihiProtocol)
+@tag('floating_pt')
+class PySpikeModelFloat(AbstractPySpikeModel):
+    s_out: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, float)
+    data: np.ndarray = LavaPyType(np.ndarray, float)

--- a/src/lava/proc/io/dataloader.py
+++ b/src/lava/proc/io/dataloader.py
@@ -17,7 +17,7 @@ from lava.magma.core.model.py.model import PyLoihiProcessModel
 
 
 # State dataloader ###########################################################
-class State(AbstractProcess):
+class StateDataloader(AbstractProcess):
     """Dataloader object that loads new data sample to internal state at a
     set interval and offset (phase).
 
@@ -93,20 +93,20 @@ class AbstractPyStateModel(PyLoihiProcessModel):
             self.sample_id = 0
 
 
-@implements(proc=State, protocol=LoihiProtocol)
+@implements(proc=StateDataloader, protocol=LoihiProtocol)
 @tag('fixed_pt')
 class PyStateModelFixed(AbstractPyStateModel):
     state: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, np.int32)
 
 
-@implements(proc=State, protocol=LoihiProtocol)
+@implements(proc=StateDataloader, protocol=LoihiProtocol)
 @tag('floating_pt')
 class PyStateModelFloat(AbstractPyStateModel):
     state: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, float)
 
 
 # Spike Dataloader ############################################################
-class Spike(AbstractProcess):
+class SpikeDataloader(AbstractProcess):
     """Dataloader object that sends spike for a input sample at a
     set interval and offset (phase).
 
@@ -179,14 +179,14 @@ class AbstractPySpikeModel(PyLoihiProcessModel):
             self.sample_id = 0
 
 
-@implements(proc=Spike, protocol=LoihiProtocol)
+@implements(proc=SpikeDataloader, protocol=LoihiProtocol)
 @tag('fixed_pt')
 class PySpikeModelFixed(AbstractPySpikeModel):
     s_out: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, np.int32)
     data: np.ndarray = LavaPyType(np.ndarray, np.int32)
 
 
-@implements(proc=Spike, protocol=LoihiProtocol)
+@implements(proc=SpikeDataloader, protocol=LoihiProtocol)
 @tag('floating_pt')
 class PySpikeModelFloat(AbstractPySpikeModel):
     s_out: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, float)

--- a/src/lava/proc/lif/models.py
+++ b/src/lava/proc/lif/models.py
@@ -72,8 +72,8 @@ class AbstractPyLifModelFixed(PyLoihiProcessModel):
     bias: np.ndarray = LavaPyType(np.ndarray, np.int16, precision=13)
     bias_exp: np.ndarray = LavaPyType(np.ndarray, np.int16, precision=3)
 
-    def __init__(self):
-        super(AbstractPyLifModelFixed, self).__init__()
+    def __init__(self, proc_params):
+        super(AbstractPyLifModelFixed, self).__init__(proc_params)
         # ds_offset and dm_offset are 1-bit registers in Loihi 1, which are
         # added to du and dv variables to compute effective decay constants
         # for current and voltage, respectively. They enable setting decay
@@ -266,8 +266,8 @@ class PyLifModelBitAcc(AbstractPyLifModelFixed):
     s_out: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, bool, precision=1)
     vth: int = LavaPyType(int, np.int32, precision=17)
 
-    def __init__(self):
-        super(PyLifModelBitAcc, self).__init__()
+    def __init__(self, proc_params):
+        super(PyLifModelBitAcc, self).__init__(proc_params)
         self.effective_vth = 0
 
     def scale_threshold(self):
@@ -300,8 +300,8 @@ class PyTernLifModelFixed(AbstractPyLifModelFixed):
     vth_hi: np.ndarray = LavaPyType(np.ndarray, np.int32, precision=24)
     vth_lo: np.ndarray = LavaPyType(np.ndarray, np.int32, precision=24)
 
-    def __init__(self):
-        super(PyTernLifModelFixed, self).__init__()
+    def __init__(self, proc_params):
+        super(PyTernLifModelFixed, self).__init__(proc_params)
         self.effective_vth_hi = 0
         self.effective_vth_lo = 0
 

--- a/tests/lava/magma/runtime/test_runtime_service.py
+++ b/tests/lava/magma/runtime/test_runtime_service.py
@@ -58,7 +58,7 @@ class TestRuntimeService(unittest.TestCase):
         self.assertEqual(rs.process_to_service, [])
 
     def test_runtime_service_start_run(self):
-        pm = SimpleProcessModel()
+        pm = SimpleProcessModel(proc_params={})
         sp = SimpleSyncProtocol()
         rs = SimplePyRuntimeService(protocol=sp)
         smm = SharedMemoryManager()

--- a/tests/lava/proc/io/test_dataloader.py
+++ b/tests/lava/proc/io/test_dataloader.py
@@ -209,21 +209,4 @@ class TestDataloader(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    num_steps = 30
-    shape = (5, 7)
-
-    dataloader = Spike(SpikeDataset(shape + (5,)), interval=5)
-    gt = ReceiveProcess(shape=dataloader.gt.shape, buffer=num_steps)
-    out = ReceiveProcess(shape=shape, buffer=num_steps)
-    dataloader.gt.connect(gt.a_in)
-    dataloader.s_out.connect(out.a_in)
-
-    run_condition = RunSteps(num_steps=num_steps)
-    run_config = TestRunConfig(select_tag='fixed_pt')
-    dataloader.run(condition=run_condition, run_cfg=run_config)
-    gt_data = gt.data.get()
-    out_data = out.data.get()
-    dataloader.stop()
-
-    print(f'{gt_data=}')
-    print(f'{out_data=}')
+    pass

--- a/tests/lava/proc/io/test_dataloader.py
+++ b/tests/lava/proc/io/test_dataloader.py
@@ -110,7 +110,11 @@ class TestDataloader(unittest.TestCase):
             id = (i - offset - 1) // interval
             data, gt = dataset[id]
             self.assertTrue(np.array_equal(gt, gt_data[..., i].item()))
-            self.assertTrue(np.array_equal(data, out_data[..., i]))
+            self.assertTrue(
+                np.array_equal(data, out_data[..., i]),
+                f'Expected data and out_data at {i=} to be same. '
+                f'Found {data=} and {out_data[..., i]=}'
+            )
 
     def test_spike_loader(self) -> None:
         """Tests spike dataloder"""
@@ -139,7 +143,11 @@ class TestDataloader(unittest.TestCase):
             gt_error = np.abs(gt_data[..., i:i + interval] - gt).sum()
             spike_error = np.abs(out_data[..., i:i + interval] - data).sum()
             self.assertTrue(gt_error == 0)
-            self.assertTrue(spike_error == 0)
+            self.assertTrue(
+                spike_error == 0,
+                f'Expected data and out_data at {i=} to be same. '
+                f'Found {data=} and {out_data[..., i:i + interval]=}'
+            )
 
     def test_spike_loader_less_steps(self) -> None:
         """Tests spike dataloder when data load interval is less than sample
@@ -171,7 +179,11 @@ class TestDataloader(unittest.TestCase):
             spike_error = np.abs(out_data[..., i:i + steps] - data).sum()
             gap_error = np.abs(out_data[..., i + steps:i + interval]).sum()
             self.assertTrue(gt_error == 0)
-            self.assertTrue(spike_error == 0)
+            self.assertTrue(
+                spike_error == 0,
+                f'Expected data and out_data at {i=} to be same. '
+                f'Found {data=} and {out_data[..., i:i + steps]=}'
+            )
             self.assertTrue(gap_error == 0)
 
     def test_spike_loader_more_steps(self) -> None:
@@ -205,7 +217,12 @@ class TestDataloader(unittest.TestCase):
                 out_data[..., i:i + interval] - data[..., :interval]
             ).sum()
             self.assertTrue(gt_error == 0)
-            self.assertTrue(spike_error == 0)
+            self.assertTrue(
+                spike_error == 0,
+                f'Expected data and out_data at {i=} to be same. '
+                f'Found {data[..., :interval]=} and '
+                f'{out_data[..., i:i + interval]=}'
+            )
 
 
 if __name__ == '__main__':

--- a/tests/lava/proc/io/test_dataloader.py
+++ b/tests/lava/proc/io/test_dataloader.py
@@ -1,0 +1,229 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+# See: https://spdx.org/licenses/
+
+from typing import List, Tuple
+import unittest
+import numpy as np
+
+from lava.magma.core.process.process import AbstractProcess
+from lava.magma.core.process.ports.ports import OutPort
+from lava.magma.core.process.variable import Var
+from lava.magma.core.model.py.ports import PyOutPort
+from lava.magma.core.model.py.type import LavaPyType
+
+from lava.magma.core.resources import CPU
+from lava.magma.core.decorator import implements, requires, tag
+from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
+from lava.magma.core.model.py.model import PyLoihiProcessModel
+
+from lava.proc.io.sink import RingBuffer as ReceiveProcess
+from lava.proc.io.dataloader import State, Spike
+
+from lava.magma.core.run_conditions import RunSteps
+from lava.magma.core.run_configs import RunConfig
+
+
+class TestRunConfig(RunConfig):
+    """Run configuration selects appropriate Conv ProcessModel based on tag:
+    floating point precision or Loihi bit-accurate fixed point precision"""
+    def __init__(self, select_tag: str = 'fixed_pt'):
+        super().__init__(custom_sync_domains=None)
+        self.select_tag = select_tag
+
+    def select(
+        self, _, proc_models: List[PyLoihiProcessModel]
+    ) -> PyLoihiProcessModel:
+        # print(proc_models)
+        for pm in proc_models:
+            if self.select_tag in pm.tags:
+                return pm
+        raise AssertionError('No legal ProcessModel found.')
+
+
+class DummyDataset:
+    def __init__(self, shape: tuple) -> None:
+        self.shape = shape
+
+    def __len__(self) -> int:
+        return 10
+
+    def __getitem__(self, id: int) -> Tuple[np.ndarray, int]:
+        data = np.arange(np.prod(self.shape)).reshape(self.shape) + id
+        data = data % np.prod(self.shape)
+        label = id
+        return data, label
+
+
+class SpikeDataset(DummyDataset):
+    def __getitem__(self, id: int) -> Tuple[np.ndarray, int]:
+        data = np.arange(np.prod(self.shape)).reshape(self.shape[::-1]) + id
+        data = data.transpose(np.arange(len(self.shape))[::-1]) % 13
+        data = data >= 10
+        label = id
+        return data, label
+
+
+class DummyProc(AbstractProcess):
+    def __init__(self, shape: tuple) -> None:
+        super().__init__(shape=shape)
+        self.state = Var(shape=shape, init=np.zeros(shape))
+        self.s_out = OutPort(shape=shape)
+
+
+@implements(proc=DummyProc, protocol=LoihiProtocol)
+@requires(CPU)
+@tag('fixed_pt')
+class PyDummyProc(PyLoihiProcessModel):
+    s_out: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, int)
+    state: np.ndarray = LavaPyType(np.ndarray, int)
+
+    def run_spk(self) -> None:
+        self.s_out.send(self.state)
+
+
+class TestDataloader(unittest.TestCase):
+    def test_state_loader(self) -> None:
+        """Tests state dataloder"""
+        num_steps = 30
+        shape = (5, 7)
+        interval = 5
+        offset = 2
+
+        proc = DummyProc(shape)
+        dataloader = State(DummyDataset(shape), interval, offset)
+        gt = ReceiveProcess(shape=dataloader.gt.shape, buffer=num_steps)
+        out = ReceiveProcess(shape=shape, buffer=num_steps)
+        dataloader.connect_var(proc.state)
+        dataloader.gt.connect(gt.a_in)
+        proc.s_out.connect(out.a_in)
+
+        run_condition = RunSteps(num_steps=num_steps)
+        run_config = TestRunConfig(select_tag='fixed_pt')
+        proc.run(condition=run_condition, run_cfg=run_config)
+        gt_data = gt.data.get()
+        out_data = out.data.get()
+        proc.stop()
+
+        dataset = DummyDataset(shape)
+        for i in range(offset + 1, num_steps):
+            id = (i - offset - 1) // interval
+            data, gt = dataset[id]
+            self.assertTrue(np.array_equal(gt, gt_data[..., i].item()))
+            self.assertTrue(np.array_equal(data, out_data[..., i]))
+
+    def test_spike_loader(self) -> None:
+        """Tests spike dataloder"""
+        shape = (5, 7)
+        interval = 5
+        offset = 2
+        num_steps = 31 + offset
+
+        dataloader = Spike(SpikeDataset(shape + (interval,)), interval, offset)
+        gt = ReceiveProcess(shape=dataloader.gt.shape, buffer=num_steps)
+        out = ReceiveProcess(shape=shape, buffer=num_steps)
+        dataloader.gt.connect(gt.a_in)
+        dataloader.s_out.connect(out.a_in)
+
+        run_condition = RunSteps(num_steps=num_steps)
+        run_config = TestRunConfig(select_tag='fixed_pt')
+        dataloader.run(condition=run_condition, run_cfg=run_config)
+        gt_data = gt.data.get()
+        out_data = out.data.get()
+        dataloader.stop()
+
+        dataset = SpikeDataset(shape + (interval,))
+        for i in range(offset + 1, num_steps, interval):
+            id = (i - offset - 1) // interval
+            data, gt = dataset[id]
+            gt_error = np.abs(gt_data[..., i:i + interval] - gt).sum()
+            spike_error = np.abs(out_data[..., i:i + interval] - data).sum()
+            self.assertTrue(gt_error == 0)
+            self.assertTrue(spike_error == 0)
+
+    def test_spike_loader_less_steps(self) -> None:
+        """Tests spike dataloder when data load interval is less than sample
+        time steps"""
+        shape = (5, 7)
+        steps = 3
+        interval = 5
+        offset = 2
+        num_steps = 31 + offset
+
+        dataloader = Spike(SpikeDataset(shape + (steps,)), interval, offset)
+        gt = ReceiveProcess(shape=dataloader.gt.shape, buffer=num_steps)
+        out = ReceiveProcess(shape=shape, buffer=num_steps)
+        dataloader.gt.connect(gt.a_in)
+        dataloader.s_out.connect(out.a_in)
+
+        run_condition = RunSteps(num_steps=num_steps)
+        run_config = TestRunConfig(select_tag='fixed_pt')
+        dataloader.run(condition=run_condition, run_cfg=run_config)
+        gt_data = gt.data.get()
+        out_data = out.data.get()
+        dataloader.stop()
+
+        dataset = SpikeDataset(shape + (steps,))
+        for i in range(offset + 1, num_steps, interval):
+            id = (i - offset - 1) // interval
+            data, gt = dataset[id]
+            gt_error = np.abs(gt_data[..., i:i + interval] - gt).sum()
+            spike_error = np.abs(out_data[..., i:i + steps] - data).sum()
+            gap_error = np.abs(out_data[..., i + steps:i + interval]).sum()
+            self.assertTrue(gt_error == 0)
+            self.assertTrue(spike_error == 0)
+            self.assertTrue(gap_error == 0)
+
+    def test_spike_loader_more_steps(self) -> None:
+        """Tests spike dataloder when data load interval is less than sample
+        time steps."""
+        shape = (5, 7)
+        steps = 8
+        interval = 5
+        offset = 2
+        num_steps = 31 + offset
+
+        dataloader = Spike(SpikeDataset(shape + (steps,)), interval, offset)
+        gt = ReceiveProcess(shape=dataloader.gt.shape, buffer=num_steps)
+        out = ReceiveProcess(shape=shape, buffer=num_steps)
+        dataloader.gt.connect(gt.a_in)
+        dataloader.s_out.connect(out.a_in)
+
+        run_condition = RunSteps(num_steps=num_steps)
+        run_config = TestRunConfig(select_tag='fixed_pt')
+        dataloader.run(condition=run_condition, run_cfg=run_config)
+        gt_data = gt.data.get()
+        out_data = out.data.get()
+        dataloader.stop()
+
+        dataset = SpikeDataset(shape + (steps,))
+        for i in range(offset + 1, num_steps, interval):
+            id = (i - offset - 1) // interval
+            data, gt = dataset[id]
+            gt_error = np.abs(gt_data[..., i:i + interval] - gt).sum()
+            spike_error = np.abs(
+                out_data[..., i:i + interval] - data[..., :interval]
+            ).sum()
+            self.assertTrue(gt_error == 0)
+            self.assertTrue(spike_error == 0)
+
+
+if __name__ == '__main__':
+    num_steps = 30
+    shape = (5, 7)
+
+    dataloader = Spike(SpikeDataset(shape + (5,)), interval=5)
+    gt = ReceiveProcess(shape=dataloader.gt.shape, buffer=num_steps)
+    out = ReceiveProcess(shape=shape, buffer=num_steps)
+    dataloader.gt.connect(gt.a_in)
+    dataloader.s_out.connect(out.a_in)
+
+    run_condition = RunSteps(num_steps=num_steps)
+    run_config = TestRunConfig(select_tag='fixed_pt')
+    dataloader.run(condition=run_condition, run_cfg=run_config)
+    gt_data = gt.data.get()
+    out_data = out.data.get()
+    dataloader.stop()
+
+    print(f'{gt_data=}')
+    print(f'{out_data=}')


### PR DESCRIPTION
Implemented proc_params in process model constructor and used it for dataloader processes.

Signed-off-by: bamsumit <bam_sumit@hotmail.com>

<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request:

## Pull request checklist

Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`pyb`) passes locally
- [x] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- We cannot communicate anything other than PyPorts and Vars between process and process model constructor

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- Process params is available in the process model constructor.
- New resource type `HostCPU` to indicate the process model must run on Host CPU.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

The execution may halt if you have overloaded the process model constructor without `proc_params` argument. The intended way to overload is
```python
def __init__(self, proc_params):
    super(<YourProcModel>, self).__init__(proc_params)
```

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
