### PR TITLE
Use unittest ci

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -63,6 +63,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install .
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -59,11 +59,7 @@ jobs:
       with:
         python-version: 3.9
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pybuilder
 
     - name: Run unit tests
       run: |
-        pyb -E unit
+        python -m unittest

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -59,6 +59,10 @@ jobs:
       with:
         python-version: 3.9
 
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
 
     - name: Run unit tests
       run: |


### PR DESCRIPTION
Objective of pull request: Fix intermittent CI failures

## Pull request checklist

Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [x] Lint (`pyb`) passes locally
- [x] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
- [x] Bugfix
- [x] Build related changes


## What is the current behavior?
- unit tests stall without error intermittently

## What is the new behavior?
- Use unittest module directly and allow unit tests complete either successfully or with errors, failures in a relatively short amount of time.

## Does this introduce a breaking change?
- [x] No
