### PR TITLE
Multiproc bug

### DIFF
--- a/src/lava/magma/runtime/message_infrastructure/multiprocessing.py
+++ b/src/lava/magma/runtime/message_infrastructure/multiprocessing.py
@@ -8,6 +8,7 @@ if ty.TYPE_CHECKING:
         AbstractRuntimeServiceBuilder
 
 import multiprocessing as mp
+import os
 from multiprocessing.managers import SharedMemoryManager
 import traceback
 
@@ -76,7 +77,8 @@ class MultiProcessing(MessageInfrastructureInterface):
     def stop(self):
         """Stops the shared memory manager"""
         for actor in self._actors:
-            actor.join()
+            if actor._parent_pid == os.getpid():
+                actor.join()
 
         self._smm.shutdown()
 


### PR DESCRIPTION
Issue Number: #176

Objective of pull request: Fix Multiprocessing AssertionError: can only join a child process

## Pull request checklist

Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`pyb`) passes locally
- [x] Build tests (`pyb -E unit`) or (`python -m unittest`) passes locally


## Pull request type

Please check your PR type:
- [x] Bugfix

## What is the current behavior?
- When unit test are run the following error is present (see: https://github.com/lava-nc/lava/runs/5132279352?check_suite_focus=true#step:5:81 for example):
packages/lava/magma/runtime/message_infrastructure/multiprocessing.py", line 79, in stop
actor.join()
File "/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/multiprocessing/process.py", line 147, in join
assert self._parent_pid == os.getpid(), 'can only join a child process'
AssertionError: can only join a child process

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- actor processes can join successfully after a check, fixing "AssertionError: can only join a child process"

## Does this introduce a breaking change?
- [x] No