### PR TITLE
Virtual ports inherit capabilities of their parent ports (#234)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ numpy = "^1.22.2"
 pytest = "^7.0.1"
 scipy = "^1.8.0"
 unittest2 = "^1.1.0"
+wrapt = "^1.14.0"
 
 [tool.poetry.dev-dependencies]
 bandit = "1.7.2"

--- a/tests/lava/magma/core/process/ports/test_ports.py
+++ b/tests/lava/magma/core/process/ports/test_ports.py
@@ -330,6 +330,53 @@ class TestRVPorts(unittest.TestCase):
         self.assertIsInstance(vps[1], VarPort)
         self.assertNotEqual(vps[0], vps[1])
 
+    # TODO (MR): Remove this unit test as soon as 1:many connections are
+    #  implemented.
+    def test_connect_RefPort_to_many_Vars_raises_exception(self):
+        """Checks that a RefPort cannot be connected to many Vars."""
+
+        # We can have multiple Vars...
+        v1 = Var((1, 2, 3))
+        v2 = Var((1, 2, 3))
+        # ...and connect a RefPort to them
+        rp = RefPort((1, 2, 3))
+        with self.assertRaises(AssertionError):
+            rp.connect_var([v1, v2])
+
+    # TODO (MR): Remove this unit test as soon as 1:many connections are
+    #  implemented.
+    def test_connect_RefPort_to_connected_RefPort_raises_exception(self):
+        """Checks that a RefPort cannot be connected to another RefPort that
+        alread has an incoming connection."""
+
+        rp1 = RefPort((1, 2, 3))
+        rp2 = RefPort((1, 2, 3))
+        rp3 = RefPort((1, 2, 3))
+
+        # We can connect two RefPorts...
+        rp1.connect(rp3)
+
+        # ...but we cannot connect another RefPort to one that has already
+        # been connected.
+        with self.assertRaises(AssertionError):
+            rp2.connect(rp3)
+
+    # TODO (MR): Remove this unit test as soon as 1:many connections are
+    #  implemented.
+    def test_connect_RefPort_to_multiple_RefPorts_raises_exception(self):
+        """Checks that a RefPort cannot be connected multiple RefPorts."""
+
+        rp1 = RefPort((1, 2, 3))
+        rp2 = RefPort((1, 2, 3))
+        rp3 = RefPort((1, 2, 3))
+
+        # We can connect two RefPorts...
+        rp1.connect(rp3)
+
+        # ...but we cannot connect the first RefPort to another RefPort.
+        with self.assertRaises(AssertionError):
+            rp1.connect(rp2)
+
     def test_connect_RefPort_to_Var_with_incompatible_shape(self):
         """Checks that shapes must be compatible when connecting ports."""
 


### PR DESCRIPTION
Signed-off-by: Mathis Richter <mathis.richter@intel.com>

<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: #234

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: Virtual ports should inherit the capabilities of their parent ports

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [ ] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [x] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- When a virtual port is created, it has a number of generic capabilities, like connecting. But when creating a virtual port on a RefPort, the user cannot use the connect_var() method on the virtual port.

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- When a virtual port is created, it inherits those capabilities of its parent port that make sense for the virtual port. This includes `connect_var()` from RefPort.

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
