### PR TITLE
Fix default sync domain not splitting processes according to the Node

### DIFF
--- a/src/lava/magma/compiler/compiler.py
+++ b/src/lava/magma/compiler/compiler.py
@@ -614,8 +614,15 @@ class Compiler:
 
             # Add process to existing or new default sync domain if not part
             # of custom sync domain
+            #  TODO: This will only work if c and ncc process end up on same sync domain and python in different
+            #  TODO: In future if we have CProcess running with Python on  same node, this will fail.
+            default_py_sd_name = proto.__name__ + "_PY" + "_SyncDomain"
+            default_c_nc_sd_name = proto.__name__ + "_NC" + "_SyncDomain"
             if p not in proc_to_domain_map:
-                default_sd_name = proto.__name__ + "_SyncDomain"
+                if issubclass(pm, AbstractPyProcessModel):
+                    default_sd_name = default_py_sd_name
+                else:
+                    default_sd_name = default_c_nc_sd_name
                 if default_sd_name in sync_domains:
                     # Default sync domain for current protocol already exists
                     sd = sync_domains[default_sd_name]

--- a/src/lava/magma/compiler/compiler.py
+++ b/src/lava/magma/compiler/compiler.py
@@ -614,16 +614,10 @@ class Compiler:
 
             # Add process to existing or new default sync domain if not part
             # of custom sync domain
-            #  TODO: This will only work if c and ncc process end up on same
-            #  sync domain and python in different. In future, if we have
-            #  CProcess running with Python on  same node, this will fail.
-            default_py_sd_name = proto.__name__ + "_PY" + "_SyncDomain"
-            default_c_nc_sd_name = proto.__name__ + "_NC" + "_SyncDomain"
             if p not in proc_to_domain_map:
-                if issubclass(pm, AbstractPyProcessModel):
-                    default_sd_name = default_py_sd_name
-                else:
-                    default_sd_name = default_c_nc_sd_name
+                default_sd_name = proto.__name__ + "_SyncDomain"
+                if not issubclass(pm, AbstractPyProcessModel):
+                    default_sd_name = proto.__name__ + "_Nc_C" + "_SyncDomain"
                 if default_sd_name in sync_domains:
                     # Default sync domain for current protocol already exists
                     sd = sync_domains[default_sd_name]

--- a/src/lava/magma/compiler/compiler.py
+++ b/src/lava/magma/compiler/compiler.py
@@ -614,8 +614,9 @@ class Compiler:
 
             # Add process to existing or new default sync domain if not part
             # of custom sync domain
-            #  TODO: This will only work if c and ncc process end up on same sync domain and python in different
-            #  TODO: In future if we have CProcess running with Python on  same node, this will fail.
+            #  TODO: This will only work if c and ncc process end up on same
+            #  sync domain and python in different. In future, if we have
+            #  CProcess running with Python on  same node, this will fail.
             default_py_sd_name = proto.__name__ + "_PY" + "_SyncDomain"
             default_c_nc_sd_name = proto.__name__ + "_NC" + "_SyncDomain"
             if p not in proc_to_domain_map:


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: Fixes issue of default sync domain not splitting processes according to the Node.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
- [ ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [ x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [ ] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [ x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [ ] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
-

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
-

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
