### PR TITLE
Add type to isinstance call

### DIFF
--- a/src/lava/magma/compiler/compiler.py
+++ b/src/lava/magma/compiler/compiler.py
@@ -309,18 +309,18 @@ class Compiler:
             # ...and add it to the list.
             subcompilers.append(compiler)
             # Remember the index for C and Nc subcompilers:
-            if isinstance(compiler, CProcCompiler):
+            if isinstance(compiler, type(CProcCompiler)):
                 c_idx.append(idx)
-            if isinstance(compiler, NcProcCompiler):
+            if isinstance(compiler, type(NcProcCompiler)):
                 nc_idx.append(idx)
 
         # Implement the heuristic "C-first Nc-second" whenever C and Nc
         # compilers are in the list. The subcompiler.compile is called in
         # their order of appearance in this list.
-        # ToDo: In the implementation below, we assume that there is only one
-        #  instance of each subcompiler (Py/C/Nc) per ProcGroup. This should
-        #  be true as long as the `compiler_type_to_procs` mapping comes from
-        #  `self._map_subcompiler_type_to_procs`.
+        # In the implementation below, we assume that there is only one
+        # instance of each subcompiler (Py/C/Nc) per ProcGroup. This should
+        # be true as long as the `compiler_type_to_procs` mapping comes from
+        # `self._map_subcompiler_type_to_procs`.
         # 1. Confirm that there is only one instance of C and Nc subcompilers
         if len(c_idx) > 1 or len(nc_idx) > 1:
             raise AssertionError("More than one instance of C or Nc "


### PR DESCRIPTION

Issue Number: #288

Objective of pull request:  Add type to isinstance call _create_subcompilers to fix issue where isinstance fails by not finding type of subcompiler classes.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [NA] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [x] Build tests (`pytest`) passes locally


## Pull request type


Please check your PR type:


- [x] Bugfix
