### PR TITLE
Fixed the explicit ordering of subcompilers in compilation stack: C-first-Nc-second

### DIFF
--- a/src/lava/magma/compiler/compiler.py
+++ b/src/lava/magma/compiler/compiler.py
@@ -310,9 +310,9 @@ class Compiler:
             # ...and add it to the list.
             subcompilers.append(compiler)
             # Remember the index for C and Nc subcompilers:
-            if isinstance(compiler, type(CProcCompiler)):
+            if isinstance(compiler, CProcCompiler):
                 c_idx.append(idx)
-            if isinstance(compiler, type(NcProcCompiler)):
+            if isinstance(compiler, NcProcCompiler):
                 nc_idx.append(idx)
 
         # Implement the heuristic "C-first Nc-second" whenever C and Nc


### PR DESCRIPTION
Signed-off-by: Risbud, Sumedh <sumedh.risbud@intel.com>

Objective of pull request: Fixes issue first uncovered by lava-optimization test case. CProcCompiler is called before NcProcCompiler to correctly populate ports and channels.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
- [ ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [ ] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [ ] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [ ] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [ ] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
-

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
-

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
