### PR TITLE
Fixing np.logical_and/or problems in Connection ProcessModels

### DIFF
--- a/src/lava/magma/core/model/py/connection.py
+++ b/src/lava/magma/core/model/py/connection.py
@@ -186,14 +186,16 @@ class Connection(PyLoihiProcessModel, ABC):
         """Build and store boolean numpy arrays specifying which x and y
         traces are active."""
         # Shape : (2, )
-        self._active_x_traces = self._active_x_traces_per_dependency[0] | \
-                                self._active_x_traces_per_dependency[1] | \
-                                self._active_x_traces_per_dependency[2]
+        self._active_x_traces = \
+            self._active_x_traces_per_dependency[0] \
+            | self._active_x_traces_per_dependency[1] \
+            | self._active_x_traces_per_dependency[2]
 
         # Shape : (3, )
-        self._active_y_traces = self._active_y_traces_per_dependency[0] | \
-                                self._active_y_traces_per_dependency[1] | \
-                                self._active_y_traces_per_dependency[2]
+        self._active_y_traces = \
+            self._active_y_traces_per_dependency[0] \
+            | self._active_y_traces_per_dependency[1] \
+            | self._active_y_traces_per_dependency[2]
 
     def _build_learning_rule_appliers(self) -> None:
         """Build and store LearningRuleApplier for each active learning

--- a/src/lava/magma/core/model/py/connection.py
+++ b/src/lava/magma/core/model/py/connection.py
@@ -186,18 +186,14 @@ class Connection(PyLoihiProcessModel, ABC):
         """Build and store boolean numpy arrays specifying which x and y
         traces are active."""
         # Shape : (2, )
-        self._active_x_traces = np.logical_or(
-            self._active_x_traces_per_dependency[0],
-            self._active_x_traces_per_dependency[1],
-            self._active_x_traces_per_dependency[2],
-        )
+        self._active_x_traces = self._active_x_traces_per_dependency[0] | \
+                                self._active_x_traces_per_dependency[1] | \
+                                self._active_x_traces_per_dependency[2]
 
         # Shape : (3, )
-        self._active_y_traces = np.logical_or(
-            self._active_y_traces_per_dependency[0],
-            self._active_y_traces_per_dependency[1],
-            self._active_y_traces_per_dependency[2],
-        )
+        self._active_y_traces = self._active_y_traces_per_dependency[0] | \
+                                self._active_y_traces_per_dependency[1] | \
+                                self._active_y_traces_per_dependency[2]
 
     def _build_learning_rule_appliers(self) -> None:
         """Build and store LearningRuleApplier for each active learning
@@ -493,7 +489,7 @@ class ConnectionModelBitApproximate(Connection):
             Pre-synaptic spikes.
         """
         self.x0[s_in] = True
-        multi_spike_x = np.logical_and(self.tx > 0, s_in)
+        multi_spike_x = (self.tx > 0) & s_in
 
         x_traces = self._x_traces
         x_traces[:, multi_spike_x] = self._add_impulse(
@@ -519,7 +515,7 @@ class ConnectionModelBitApproximate(Connection):
             Post-synaptic spikes.
         """
         self.y0[s_in_bap] = True
-        multi_spike_y = np.logical_and(self.ty > 0, s_in_bap)
+        multi_spike_y = (self.ty > 0) & s_in_bap
 
         y_traces = self._y_traces
         y_traces[:, multi_spike_y] = self._add_impulse(
@@ -956,12 +952,8 @@ class ConnectionModelBitApproximate(Connection):
 
         t_diff = t_eval - t_spikes
 
-        decay_only = np.logical_and(
-            np.logical_or(t_spikes == 0, t_diff < 0), broad_taus > 0
-        )
-        decay_spike_decay = np.logical_and(
-            t_spikes != 0, t_diff >= 0, broad_taus > 0
-        )
+        decay_only = ((t_spikes == 0) | (t_diff < 0)) & (broad_taus > 0)
+        decay_spike_decay = (t_spikes != 0) & (t_diff >= 0) & (broad_taus > 0)
 
         result = trace_values.copy()
 
@@ -1160,7 +1152,7 @@ class ConnectionModelFloat(Connection):
         """
 
         self.x0[s_in] = True
-        multi_spike_x = np.logical_and(self.tx > 0, s_in)
+        multi_spike_x = (self.tx > 0) & s_in
 
         x_traces = self._x_traces
         x_traces[:, multi_spike_x] += self._x_impulses[:, np.newaxis]
@@ -1182,7 +1174,7 @@ class ConnectionModelFloat(Connection):
         """
 
         self.y0[s_in_bap] = True
-        multi_spike_y = np.logical_and(self.ty > 0, s_in_bap)
+        multi_spike_y = (self.ty > 0) & s_in_bap
 
         y_traces = self._y_traces
         y_traces[:, multi_spike_y] += self._y_impulses[:, np.newaxis]
@@ -1377,12 +1369,8 @@ class ConnectionModelFloat(Connection):
 
         t_diff = t_eval - t_spikes
 
-        decay_only = np.logical_and(
-            np.logical_or(t_spikes == 0, t_diff < 0), broad_taus > 0
-        )
-        decay_spike_decay = np.logical_and(
-            t_spikes != 0, t_diff >= 0, broad_taus > 0
-        )
+        decay_only = ((t_spikes == 0) | (t_diff < 0)) & (broad_taus > 0)
+        decay_spike_decay = (t_spikes != 0) & (t_diff >= 0) & (broad_taus > 0)
 
         result = trace_values.copy()
 


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: #411

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: Fixing incorrect use of np.logical_and and np.logical_or was discovered in learning-related code in Connection ProcessModels.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [x] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- Currently, to implement `and` and `or` element-wise operations on 3 `np.ndarray` (example : `a`, `b` and `c`), the following is used :
`np.logical_and(a, b, c)`

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- Replaced it with : 
`a & b & c`

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [x] No