### PR TITLE
Fixed automatic append of py_ports and var_ports

### DIFF
--- a/src/lava/magma/compiler/channels/pypychannel.py
+++ b/src/lava/magma/compiler/channels/pypychannel.py
@@ -238,7 +238,6 @@ class CspRecvPort(AbstractCspRecvPort):
             )
             for i in range(self._size)
         ]
-        self._result = np.ndarray(shape=self._shape, dtype=self._dtype)
         self._queue = CspRecvQueue(self._size)
         self.thread = Thread(
             target=self._req_callback,
@@ -271,18 +270,18 @@ class CspRecvPort(AbstractCspRecvPort):
         if there is no data on the channel.
         """
         self._queue.get(peek=True)
-        np.copyto(self._result, self._array[self._idx])
-        return self._result
+        result = self._array[self._idx].copy()
+        return result
 
     def recv(self):
         """
         Receive from the channel. Blocks if there is no data on the channel.
         """
         self._queue.get()
-        np.copyto(self._result, self._array[self._idx])
+        result = self._array[self._idx].copy()
         self._idx = (self._idx + 1) % self._size
         self._ack.release()
-        return self._result
+        return result
 
     def join(self):
         if not self._done:

--- a/src/lava/magma/compiler/channels/pypychannel.py
+++ b/src/lava/magma/compiler/channels/pypychannel.py
@@ -202,6 +202,7 @@ class CspRecvPort(AbstractCspRecvPort):
         self._idx = 0
         self._done = False
         self._array = []
+        self._result = None
         self._queue = None
         self.observer = None
         self.thread = None
@@ -237,6 +238,7 @@ class CspRecvPort(AbstractCspRecvPort):
             )
             for i in range(self._size)
         ]
+        self._result = np.ndarray(shape=self._shape, dtype=self._dtype)
         self._queue = CspRecvQueue(self._size)
         self.thread = Thread(
             target=self._req_callback,
@@ -269,19 +271,21 @@ class CspRecvPort(AbstractCspRecvPort):
         if there is no data on the channel.
         """
         self._queue.get(peek=True)
-        result = self._array[self._idx].copy()
-        return result
+        #result = self._array[self._idx].copy()
+        np.copyto(self._result, self._array[self._idx])
+        return self._result
 
     def recv(self):
         """
         Receive from the channel. Blocks if there is no data on the channel.
         """
         self._queue.get()
-        result = self._array[self._idx].copy()
+        #result = self._array[self._idx].copy()
+        np.copyto(self._result, self._array[self._idx])
         self._idx = (self._idx + 1) % self._size
         self._ack.release()
-
-        return result
+        return self._result
+        #return self._array[self._idx]
 
     def join(self):
         if not self._done:

--- a/src/lava/magma/compiler/channels/pypychannel.py
+++ b/src/lava/magma/compiler/channels/pypychannel.py
@@ -280,7 +280,6 @@ class CspRecvPort(AbstractCspRecvPort):
         result = self._array[self._idx].copy()
         self._idx = (self._idx + 1) % self._size
         self._ack.release()
-        
         return result
 
     def join(self):

--- a/src/lava/magma/compiler/channels/pypychannel.py
+++ b/src/lava/magma/compiler/channels/pypychannel.py
@@ -271,7 +271,6 @@ class CspRecvPort(AbstractCspRecvPort):
         if there is no data on the channel.
         """
         self._queue.get(peek=True)
-        #result = self._array[self._idx].copy()
         np.copyto(self._result, self._array[self._idx])
         return self._result
 
@@ -280,12 +279,10 @@ class CspRecvPort(AbstractCspRecvPort):
         Receive from the channel. Blocks if there is no data on the channel.
         """
         self._queue.get()
-        #result = self._array[self._idx].copy()
         np.copyto(self._result, self._array[self._idx])
         self._idx = (self._idx + 1) % self._size
         self._ack.release()
         return self._result
-        #return self._array[self._idx]
 
     def join(self):
         if not self._done:

--- a/src/lava/magma/compiler/channels/pypychannel.py
+++ b/src/lava/magma/compiler/channels/pypychannel.py
@@ -202,7 +202,6 @@ class CspRecvPort(AbstractCspRecvPort):
         self._idx = 0
         self._done = False
         self._array = []
-        self._result = None
         self._queue = None
         self.observer = None
         self.thread = None
@@ -281,6 +280,7 @@ class CspRecvPort(AbstractCspRecvPort):
         result = self._array[self._idx].copy()
         self._idx = (self._idx + 1) % self._size
         self._ack.release()
+        
         return result
 
     def join(self):

--- a/src/lava/magma/core/model/py/model.py
+++ b/src/lava/magma/core/model/py/model.py
@@ -74,9 +74,9 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
 
         """
         self.__dict__[key] = value
-        if isinstance(value, AbstractPyPort) and not value in self.py_ports:
+        if isinstance(value, AbstractPyPort) and value not in self.py_ports:
             self.py_ports.append(value)
-            if isinstance(value, PyVarPort) and not value in self.var_ports:
+            if isinstance(value, PyVarPort) and value not in self.var_ports:
                 self.var_ports.append(value)
 
     def start(self):

--- a/src/lava/magma/core/model/py/model.py
+++ b/src/lava/magma/core/model/py/model.py
@@ -74,10 +74,9 @@ class AbstractPyProcessModel(AbstractProcessModel, ABC):
 
         """
         self.__dict__[key] = value
-        if isinstance(value, AbstractPyPort):
+        if isinstance(value, AbstractPyPort) and not value in self.py_ports:
             self.py_ports.append(value)
-            # Store all VarPorts for efficient RefPort -> VarPort handling
-            if isinstance(value, PyVarPort):
+            if isinstance(value, PyVarPort) and not value in self.var_ports:
                 self.var_ports.append(value)
 
     def start(self):

--- a/src/lava/magma/core/model/py/ports.py
+++ b/src/lava/magma/core/model/py/ports.py
@@ -699,13 +699,16 @@ class PyRefPortVectorDense(PyRefPort):
             The value of the referenced Var.
         """
         if self._csp_send_port and self._csp_recv_port:
-            header = np.ones(self._csp_send_port.shape) * VarPortCmd.GET
-            self._csp_send_port.send(header)
-
+            if not hasattr(self, 'get_header'):
+                self.get_header = np.ones(self._csp_send_port.shape) * VarPortCmd.GET
+            self._csp_send_port.send(self.get_header)
             return self._transformer.transform(self._csp_recv_port.recv(),
                                                self._csp_recv_port)
-
-        return np.zeros(self._shape, self._d_type)
+            #return np.zeros(self.shape, self._d_type)
+        else:
+            if not hasattr(self, 'get_zeros'):
+                self.get_zeros = np.zeros(self._shape, self._d_type)
+            return self.get_zeros
 
     def write(self, data: np.ndarray):
         """Abstract method to write data to a VarPort to set the value of the
@@ -717,8 +720,9 @@ class PyRefPortVectorDense(PyRefPort):
             The data to send via _csp_send_port.
         """
         if self._csp_send_port:
-            header = np.ones(self._csp_send_port.shape) * VarPortCmd.SET
-            self._csp_send_port.send(header)
+            if not hasattr(self, 'set_header'):
+                self.set_header = np.ones(self._csp_send_port.shape) * VarPortCmd.SET
+            self._csp_send_port.send(self.set_header)
             self._csp_send_port.send(data)
 
 

--- a/src/lava/magma/core/model/py/ports.py
+++ b/src/lava/magma/core/model/py/ports.py
@@ -700,11 +700,11 @@ class PyRefPortVectorDense(PyRefPort):
         """
         if self._csp_send_port and self._csp_recv_port:
             if not hasattr(self, 'get_header'):
-                self.get_header = np.ones(self._csp_send_port.shape) * VarPortCmd.GET
+                self.get_header = (np.ones(self._csp_send_port.shape)
+                                   * VarPortCmd.GET)
             self._csp_send_port.send(self.get_header)
             return self._transformer.transform(self._csp_recv_port.recv(),
                                                self._csp_recv_port)
-            #return np.zeros(self.shape, self._d_type)
         else:
             if not hasattr(self, 'get_zeros'):
                 self.get_zeros = np.zeros(self._shape, self._d_type)
@@ -721,7 +721,8 @@ class PyRefPortVectorDense(PyRefPort):
         """
         if self._csp_send_port:
             if not hasattr(self, 'set_header'):
-                self.set_header = np.ones(self._csp_send_port.shape) * VarPortCmd.SET
+                self.set_header = (np.ones(self._csp_send_port.shape)
+                                   * VarPortCmd.SET)
             self._csp_send_port.send(self.set_header)
             self._csp_send_port.send(data)
 


### PR DESCRIPTION
Added a check to prevent re-appending the same PyPort or VarPort that is already in a process model's py_ports or var_ports list.

Adjusted CspRecvPort implementation to allocate numpy _result array once at initialization rather than on every update.

Adjusted PyRefPortVectorDense to allocate header numpy arrays the first time they are used, rather than every time a value is sent.

Issue Number: #586 

Objective of pull request:
Fix incorrect append of py_ports and var_ports on each process model update, resulting in significant slowdown over time when using varports (e.g. Monitor).

Your PR fulfills the following requirements:
- [Y] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [N] Tests are part of the PR (for bug fixes / features)
- [N] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [Y] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [Y] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [Y] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [x] Build tests (`pytest`) passes locally

One test in test_learning_rule.py seems to be stalling, I don't think this is due to these changes, but will investigate further.

Please check your PR type:
- [X] Bugfix

## What is the current behavior?
- Execution time of .read() on a RefPort grows the more we call it.

## What is the new behavior?
- Execution time of .read() on a RefPort is stable over the course of thousands of timesteps.

## Does this introduce a breaking change?
- [X] No
