### PR TITLE
Added process.create_runtime method

### DIFF
--- a/tests/lava/magma/core/process/test_process.py
+++ b/tests/lava/magma/core/process/test_process.py
@@ -38,11 +38,16 @@ class MinimalProcess(AbstractProcess):
         super().__init__(name=name)
 
 
+class MinimalRuntimeService:
+    __name__ = 'MinimalRuntimeService'
+
+    def __init__(self):
+        pass
+
 class MinimalProtocol(AbstractSyncProtocol):
     @property
     def runtime_service(self):
-        rt_svc = type('MinimalRuntimeService', (object,), {})
-        return {CPU: rt_svc}
+        return {CPU: MinimalRuntimeService()}
 
 
 @implements(proc=MinimalProcess, protocol=MinimalProtocol)
@@ -311,7 +316,7 @@ class TestProcess(unittest.TestCase):
         p.create_runtime(run_cfg)
         r = p.runtime
         self.assertIsInstance(r, Runtime)
-        self.assert_(r._is_initialized)
+        self.assertTrue(r._is_initialized)
         self.assertFalse(r._is_started)
         self.assertFalse(r._is_running)
 

--- a/tests/lava/magma/core/process/test_process.py
+++ b/tests/lava/magma/core/process/test_process.py
@@ -6,6 +6,10 @@ import logging
 import unittest
 from unittest.mock import Mock, seal
 import typing as ty
+from lava.magma.compiler.executable import Executable
+from lava.magma.core.decorator import implements, requires
+from lava.magma.core.model.py.model import AbstractPyProcessModel
+from lava.magma.core.model.sub.model import AbstractSubProcessModel
 
 from lava.magma.core.process.ports.ports import (
     InPort,
@@ -20,7 +24,11 @@ from lava.magma.core.process.process import (
 )
 from lava.magma.core.model.model import AbstractProcessModel
 from lava.magma.core.process.variable import Var
+from lava.magma.core.resources import CPU
 from lava.magma.core.run_conditions import RunSteps
+from lava.magma.core.run_configs import RunConfig
+from lava.magma.core.sync.protocol import AbstractSyncProtocol
+from lava.magma.runtime.runtime import Runtime
 
 
 class MinimalProcess(AbstractProcess):
@@ -28,6 +36,28 @@ class MinimalProcess(AbstractProcess):
 
     def __init__(self, name: ty.Optional[str] = None):
         super().__init__(name=name)
+
+
+class MinimalProtocol(AbstractSyncProtocol):
+    @property
+    def runtime_service(self):
+        rt_svc = type('MinimalRuntimeService', (object,), {})
+        return {CPU: rt_svc}
+
+
+@implements(proc=MinimalProcess, protocol=MinimalProtocol)
+@requires(CPU)
+class MinimalPyProcessModel(AbstractPyProcessModel):
+    def run(self):
+        raise NotImplementedError('This model doesnt run')
+
+
+class MinimalRunConfig(RunConfig):
+    def __init__(self):
+        super().__init__(custom_sync_domains=None, loglevel=logging.WARNING)
+
+    def select(self, proc, proc_models):
+        return proc_models[0]
 
 
 class TestCollection(unittest.TestCase):
@@ -259,12 +289,31 @@ class TestProcess(unittest.TestCase):
     def test_model_property(self) -> None:
         """Tests whether the ProcessModel of a Process can be obtained
         through a property method."""
-
         p = MinimalProcess()
         p._model_class = Mock(spec_set=AbstractProcessModel)
         seal(p._model_class)
-
         self.assertIsInstance(p.model_class, AbstractProcessModel)
+
+    def test_compile(self) -> None:
+        """Test whether compile creates an executable which is ready
+        to build the process model for a simple process."""
+        p = MinimalProcess()
+        run_cfg = MinimalRunConfig()
+        e = p.compile(run_cfg)
+        self.assertIsInstance(e, Executable)
+        self.assertEqual(len(e.proc_builders), 1)
+
+    def test_create_runtime(self) -> None:
+        """Tests the create_runtime method."""
+        p = MinimalProcess()
+        self.assertIsNone(p.runtime)
+        run_cfg = MinimalRunConfig()
+        p.create_runtime(run_cfg)
+        r = p.runtime
+        self.assertIsInstance(r, Runtime)
+        self.assert_(r._is_initialized)
+        self.assertFalse(r._is_started)
+        self.assertFalse(r._is_running)
 
     def test_run_without_run_config_raises_error(self) -> None:
         """Tests whether an error is raised when run() is called on

--- a/tests/lava/magma/core/process/test_process.py
+++ b/tests/lava/magma/core/process/test_process.py
@@ -44,6 +44,7 @@ class MinimalRuntimeService:
     def __init__(self):
         pass
 
+
 class MinimalProtocol(AbstractSyncProtocol):
     @property
     def runtime_service(self):


### PR DESCRIPTION
Issue Number: #673 

Objective of pull request:
Add a method to process to create and initialize a runtime without running it.

Your PR fulfills the following requirements:
- [Y] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [Y] Tests are part of the PR (for bug fixes / features)
- [Y] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [Y] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [Y] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [Y] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [Y] Build tests (`pytest`) passes locally

## Pull request type
Please check your PR type:
- [X] Feature

## What is the current behavior?
- Process creates and initializes runtime the first time run is called.

## What is the new behavior?
- Process creates and initializes runtime when create_runtime is called, which will be automatically called from run if no runtime is already created.

## Does this introduce a breaking change?
- [X] No
