### PR TITLE
Bugfix to enable monitoring aliased vars

### DIFF
--- a/src/lava/magma/core/process/ports/ports.py
+++ b/src/lava/magma/core/process/ports/ports.py
@@ -646,16 +646,11 @@ class RefPort(AbstractRVPort, AbstractSrcPort):
             vp.process = var.process
             # VarPort name could shadow existing attribute
             if hasattr(var.process, vp.name):
-                found_unique_name = False
-                name = ""
-                i = 0
-                # Find a unique name
-                while not found_unique_name:
-                    i += 1
-                    name = vp.name + "_" + str(i)
-                    if not hasattr(var.process, name):
-                        found_unique_name = True
-                vp.name = name
+                name = str(vp.name)
+                name_suffix = 0
+                while hasattr(var.process, vp.name):
+                    vp.name = name + "_" + str(name_suffix)
+                    name_suffix += 1
             setattr(var.process, vp.name, vp)
             var.process.var_ports.add_members({vp.name: vp})
 

--- a/src/lava/magma/core/process/ports/ports.py
+++ b/src/lava/magma/core/process/ports/ports.py
@@ -646,11 +646,16 @@ class RefPort(AbstractRVPort, AbstractSrcPort):
             vp.process = var.process
             # VarPort name could shadow existing attribute
             if hasattr(var.process, vp.name):
-                # TODO : Implement proper strategy to handle this case
-                # raise AssertionError(
-                #     "Name of implicit VarPort might conflict"
-                #     " with existing attribute.")
-                vp.name = vp.name + "_1"
+                found_unique_name = False
+                name = ""
+                i = 0
+                # Find a unique name
+                while not found_unique_name:
+                    i += 1
+                    name = vp.name + "_" + str(i)
+                    if not hasattr(var.process, vp.name):
+                        found_unique_name = True
+                vp.name = name
             setattr(var.process, vp.name, vp)
             var.process.var_ports.add_members({vp.name: vp})
 

--- a/src/lava/magma/core/process/ports/ports.py
+++ b/src/lava/magma/core/process/ports/ports.py
@@ -647,7 +647,7 @@ class RefPort(AbstractRVPort, AbstractSrcPort):
             # VarPort name could shadow existing attribute
             if hasattr(var.process, vp.name):
                 name = str(vp.name)
-                name_suffix = 0
+                name_suffix = 1
                 while hasattr(var.process, vp.name):
                     vp.name = name + "_" + str(name_suffix)
                     name_suffix += 1

--- a/src/lava/magma/core/process/ports/ports.py
+++ b/src/lava/magma/core/process/ports/ports.py
@@ -653,7 +653,7 @@ class RefPort(AbstractRVPort, AbstractSrcPort):
                 while not found_unique_name:
                     i += 1
                     name = vp.name + "_" + str(i)
-                    if not hasattr(var.process, vp.name):
+                    if not hasattr(var.process, name):
                         found_unique_name = True
                 vp.name = name
             setattr(var.process, vp.name, vp)

--- a/src/lava/magma/core/process/ports/ports.py
+++ b/src/lava/magma/core/process/ports/ports.py
@@ -646,9 +646,11 @@ class RefPort(AbstractRVPort, AbstractSrcPort):
             vp.process = var.process
             # VarPort name could shadow existing attribute
             if hasattr(var.process, vp.name):
-                raise AssertionError(
-                    "Name of implicit VarPort might conflict"
-                    " with existing attribute.")
+                # TODO : Implement proper strategy to handle this case
+                # raise AssertionError(
+                #     "Name of implicit VarPort might conflict"
+                #     " with existing attribute.")
+                vp.name = vp.name + "_1"
             setattr(var.process, vp.name, vp)
             var.process.var_ports.add_members({vp.name: vp})
 

--- a/tests/lava/magma/core/process/ports/test_ports.py
+++ b/tests/lava/magma/core/process/ports/test_ports.py
@@ -310,6 +310,15 @@ class TestRVPorts(unittest.TestCase):
         # ... and connect it directly via connect_var(..)
         rp.connect_var(v)
 
+        # This has the same effect as connecting a RefPort explicitly via a
+        # VarPort to a Var...
+        self.assertEqual(rp.get_dst_vars(), [v])
+        # ... but still creates a VarPort implicitly
+        vp = rp.get_dst_ports()[0]
+        self.assertIsInstance(vp, VarPort)
+        # ... which wraps the original Var
+        self.assertEqual(vp.var, v)
+
         # In this case, the VarPort inherits its name and parent process from
         # the Var it wraps + _implicit_port + _k with k=1,2,3...
         self.assertEqual(vp.name, "_" + v.name + "_implicit_port" + "_1")

--- a/tests/lava/magma/core/process/ports/test_ports.py
+++ b/tests/lava/magma/core/process/ports/test_ports.py
@@ -290,7 +290,8 @@ class TestRVPorts(unittest.TestCase):
 
     def test_connect_RefPort_to_Var_process_conflict(self):
         """Checks connecting RefPort implicitly to Var, with registered
-        processes and conflicting names. -> AssertionError"""
+        processes and conflicting names. -> adding _k with k=1,2,3... to
+        the name."""
 
         # Create a mock parent process
         class VarProcess(AbstractProcess):
@@ -307,9 +308,12 @@ class TestRVPorts(unittest.TestCase):
         v.name = "existing_attr"
 
         # ... and connect it directly via connect_var(..)
-        # The naming conflict should raise an AssertionError
-        with self.assertRaises(AssertionError):
-            rp.connect_var(v)
+        rp.connect_var(v)
+
+        # In this case, the VarPort inherits its name and parent process from
+        # the Var it wraps + _implicit_port + _k with k=1,2,3...
+        self.assertEqual(vp.name, "_" + v.name + "_implicit_port" + "_1")
+        self.assertEqual(vp.process, v.process)
 
     @unittest.skip("Currently not supported")
     def test_connect_RefPort_to_many_Vars(self):


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: #676 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request:

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
- [x] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [ ] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [ ] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [x] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- An assertion was raised when it was requested to create two different implicit var ports with the same name on the same process

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- The different var ports will be created without assertion, with a numerical suffix added to the name

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

- [x] No