### PR TITLE
First prototype of IO bridge Processes

### DIFF
--- a/src/lava/proc/io/input_bridge.py
+++ b/src/lava/proc/io/input_bridge.py
@@ -1,0 +1,80 @@
+import numpy as np
+import multiprocessing as mp
+
+from lava.magma.core.process.process import AbstractProcess
+from lava.magma.core.process.ports.ports import OutPort
+
+from lava.magma.core.resources import CPU
+from lava.magma.core.decorator import implements, requires, tag
+from lava.magma.core.model.py.model import PyLoihiProcessModel
+from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
+from lava.magma.core.model.py.type import LavaPyType
+from lava.magma.core.model.py.ports import PyOutPort
+
+
+# TODO : (GK) Is this really a good name ?
+class InputBridge(AbstractProcess):
+    """Process that gets data into Lava.
+
+    Parameters
+    ----------
+    out_shape : tuple
+        Shape of the OutPort of the Process.
+    """
+
+    def __init__(self, out_shape: tuple[int, ...]) -> None:
+        # TODO : (GK) I don't like having code before the call to super()... Is there a better way to do it ?
+        recv_pipe, self._send_pipe = mp.Pipe(duplex=False)
+        super().__init__(out_shape=out_shape, recv_pipe=recv_pipe)
+
+        self.out_port = OutPort(shape=out_shape)
+
+    def send_data(self, data: np.ndarray) -> None:
+        """Send data to the ProcessModel.
+
+        The data sent to the ProcessModel will be received by it, and then sent by the ProcessModel through the OutPort.
+
+        Parameters
+        ----------
+        data : np.ndarray
+            Data to get into Lava.
+        """
+        if data.shape != self.out_port.shape:
+            raise ValueError(f"Shape of data to send must be the same as the shape of the OutPort. "
+                             f"{data.shape=} != out_port.shape={self.out_port.shape}.")
+
+        self._send_pipe.send(data)
+
+
+# TODO : (GK) What's the best convention for naming ProcessModels ?
+@implements(proc=InputBridge, protocol=LoihiProtocol)
+@requires(CPU)
+@tag("floating_pt")
+class PyLoihiFloatingPointInputBridgeProcessModel(PyLoihiProcessModel):
+    """PyLoihiFloatingPointProcessModel for the InputBridge Process."""
+    out_port: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, float)
+
+    def __init__(self, proc_params: dict) -> None:
+        super().__init__(proc_params=proc_params)
+
+        self._recv_pipe: mp.connection.PipeConnection = self.proc_params["recv_pipe"]
+
+    def run_spk(self) -> None:
+        self.out_port.send(self._recv_pipe.recv())
+
+
+# TODO : (GK) What's the best convention for naming ProcessModels ?
+@implements(proc=InputBridge, protocol=LoihiProtocol)
+@requires(CPU)
+@tag("fixed_pt")
+class PyLoihiFixedPointInputBridgeProcessModel(PyLoihiProcessModel):
+    """PyLoihiFixedPointProcessModel for the InputBridge Process."""
+    out_port: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, int)
+
+    def __init__(self, proc_params: dict) -> None:
+        super().__init__(proc_params=proc_params)
+
+        self._recv_pipe: mp.connection.PipeConnection = self.proc_params["recv_pipe"]
+
+    def run_spk(self) -> None:
+        self.out_port.send(self._recv_pipe.recv())

--- a/src/lava/proc/io/output_bridge.py
+++ b/src/lava/proc/io/output_bridge.py
@@ -1,0 +1,76 @@
+import numpy as np
+import multiprocessing as mp
+
+from lava.magma.core.process.process import AbstractProcess
+from lava.magma.core.process.ports.ports import InPort
+
+from lava.magma.core.resources import CPU
+from lava.magma.core.decorator import implements, requires, tag
+from lava.magma.core.model.py.model import PyLoihiProcessModel
+from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
+from lava.magma.core.model.py.type import LavaPyType
+from lava.magma.core.model.py.ports import PyInPort
+
+
+# TODO : (GK) Is this really a good name ?
+class OutputBridge(AbstractProcess):
+    """Process that gets data out of Lava.
+
+    Parameters
+    ----------
+    shape_in : tuple
+        Shape of the InPort of the Process.
+    """
+
+    def __init__(self, in_shape: tuple[int, ...]) -> None:
+        # TODO : (GK) I don't like having code before the call to super()... Is there a better way to do it ?
+        self._recv_pipe, send_pipe = mp.Pipe(duplex=False)
+        super().__init__(in_shape=in_shape, send_pipe=send_pipe)
+
+        self.in_port = InPort(shape=in_shape)
+
+    def receive_data(self) -> np.ndarray:
+        """Receive data from the ProcessModel.
+
+        The data received from the InPort is sent from the ProcessModel and returned by this method.
+
+        Returns
+        ----------
+        data : np.ndarray
+            Data got from Lava.
+        """
+        return self._recv_pipe.recv()
+
+
+# TODO : (GK) What's the best convention for naming ProcessModels ?
+@implements(proc=OutputBridge, protocol=LoihiProtocol)
+@requires(CPU)
+@tag("floating_pt")
+class PyLoihiFloatingPointOutputBridgeProcessModel(PyLoihiProcessModel):
+    """PyLoihiFloatingPointProcessModel for the OutputBridge Process."""
+    in_port: PyInPort = LavaPyType(PyInPort.VEC_DENSE, float)
+
+    def __init__(self, proc_params: dict) -> None:
+        super().__init__(proc_params=proc_params)
+
+        self._send_pipe: mp.connection.PipeConnection = self.proc_params["send_pipe"]
+
+    def run_spk(self) -> None:
+        self._send_pipe.send(self.in_port.recv())
+
+
+# TODO : (GK) What's the best convention for naming ProcessModels ?
+@implements(proc=OutputBridge, protocol=LoihiProtocol)
+@requires(CPU)
+@tag("fixed_pt")
+class PyLoihiFixedPointOutputBridgeProcessModel(PyLoihiProcessModel):
+    """PyLoihiFixedPointProcessModel for the OutputBridge Process."""
+    in_port: PyInPort = LavaPyType(PyInPort.VEC_DENSE, float)
+
+    def __init__(self, proc_params: dict) -> None:
+        super().__init__(proc_params=proc_params)
+
+        self._send_pipe: mp.connection.PipeConnection = self.proc_params["send_pipe"]
+
+    def run_spk(self) -> None:
+        self._send_pipe.send(self.in_port.recv())

--- a/tests/lava/proc/io/test_input_bridge.py
+++ b/tests/lava/proc/io/test_input_bridge.py
@@ -1,0 +1,225 @@
+import numpy as np
+import unittest
+import multiprocessing as mp
+
+from lava.magma.core.process.process import AbstractProcess
+from lava.magma.core.process.ports.ports import InPort, OutPort
+from lava.magma.core.process.variable import Var
+
+from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
+
+from lava.magma.core.decorator import implements, requires, tag
+from lava.magma.core.resources import CPU
+
+from lava.magma.core.model.py.model import PyLoihiProcessModel
+from lava.magma.core.model.py.type import LavaPyType
+from lava.magma.core.model.py.ports import PyInPort, PyOutPort
+
+from lava.magma.core.run_configs import Loihi2SimCfg
+from lava.magma.core.run_conditions import RunSteps, RunContinuous
+
+from lava.proc.io.input_bridge import InputBridge, \
+    PyLoihiFloatingPointInputBridgeProcessModel, \
+    PyLoihiFixedPointInputBridgeProcessModel
+
+
+class Recv(AbstractProcess):
+    """Process that receives arbitrary dense data and stores it in a Var.
+
+    Parameters
+    ----------
+    shape: tuple
+        Shape of the InPort and Var.
+    """
+    def __init__(self, shape: tuple[...]):
+        super().__init__(shape=shape)
+
+        self.var = Var(shape=shape, init=0)
+        self.in_port = InPort(shape=shape)
+
+
+@implements(proc=Recv, protocol=LoihiProtocol)
+@requires(CPU)
+@tag("floating_pt")
+class PyLoihiFloatingPointRecvProcessModel(PyLoihiProcessModel):
+    """Receives dense floating point data from PyInPort and stores it in a Var."""
+    var: np.ndarray = LavaPyType(np.ndarray, float)
+    in_port: PyInPort = LavaPyType(PyInPort.VEC_DENSE, float)
+
+    def run_spk(self) -> None:
+        self.var = self.in_port.recv()
+
+
+@implements(proc=Recv, protocol=LoihiProtocol)
+@requires(CPU)
+@tag("fixed_pt")
+class PyLoihiFixedPointRecvProcessModel(PyLoihiProcessModel):
+    """Receives dense fixed point data from PyInPort and stores it in a Var."""
+    var: np.ndarray = LavaPyType(np.ndarray, int)
+    in_port: PyInPort = LavaPyType(PyInPort.VEC_DENSE, int)
+
+    def run_spk(self) -> None:
+        self.var = self.in_port.recv()
+
+
+class TestInputBridge(unittest.TestCase):
+    def test_init(self):
+        out_shape = (1, )
+
+        input_bridge = InputBridge(out_shape=out_shape)
+
+        self.assertIsInstance(input_bridge, InputBridge)
+        self.assertIsInstance(input_bridge._send_pipe, mp.connection.PipeConnection)
+        self.assertIsInstance(input_bridge.proc_params["recv_pipe"], mp.connection.PipeConnection)
+        self.assertEqual(input_bridge.out_port.shape, out_shape)
+
+    # TODO : Is this test really necessary ?
+    # def test_invalid_shape(self):
+    #     out_shape = (1.5, )
+    #
+    #     with self.assertRaises(ValueError):
+    #         InputBridge(out_shape=out_shape)
+
+    def test_send_data(self):
+        out_shape = (1,)
+
+        input_bridge = InputBridge(out_shape=out_shape)
+
+        send_data = np.ones(out_shape)
+        input_bridge.send_data(send_data)
+
+        recv_data = input_bridge.proc_params["recv_pipe"].recv()
+
+        np.testing.assert_equal(recv_data, send_data)
+
+    def test_send_data_shape_different_from_out_shape(self):
+        out_shape = (1,)
+
+        input_bridge = InputBridge(out_shape=out_shape)
+
+        data_shape = (1, 2)
+        send_data = np.ones(data_shape)
+
+        with self.assertRaises(ValueError):
+            input_bridge.send_data(send_data)
+
+    def test_send_data_multiple_times_before_receiving(self):
+        # limit for (1, ) = 54
+        # limit for (2, ) = 52
+        # limit for (3, ) = 51
+
+        # limit for (4, ) = 50
+        # limit for (4,1) = 49
+        # limit for (2,2) = 49
+
+        # limit for (50, ) = 23
+        # limit for (50, 1) = 23
+        # limit for (5, 10) = 23
+
+        # limit for (100, ) = 14
+        # limit for (500, ) = 3
+        # limit for (986, ) = 2
+        # limit for (2010, ) = 1
+        # limit for (2011, ) = 0
+
+        num_consecutive_send_before_receive = 50
+        out_shape = (4, )
+
+        input_bridge = InputBridge(out_shape=out_shape)
+
+        complete_send_data = [np.full(out_shape, i) for i in range(num_consecutive_send_before_receive)]
+
+        for send_data in complete_send_data:
+            input_bridge.send_data(send_data)
+
+        complete_recv_data = []
+
+        for _ in range(num_consecutive_send_before_receive):
+            complete_recv_data.append(input_bridge.proc_params["recv_pipe"].recv())
+
+        np.testing.assert_equal(complete_recv_data, complete_send_data)
+
+
+class TestInputBridgeFloatingPointProcessModel(unittest.TestCase):
+    def test_init(self):
+        out_shape = (1, )
+        recv_pipe, _ = mp.Pipe(duplex=False)
+        proc_params = {
+            "out_shape": out_shape,
+            "recv_pipe": recv_pipe
+        }
+
+        process_model = PyLoihiFloatingPointInputBridgeProcessModel(proc_params=proc_params)
+
+        self.assertIsInstance(process_model, PyLoihiFloatingPointInputBridgeProcessModel)
+        self.assertIsInstance(process_model._recv_pipe, mp.connection.PipeConnection)
+
+    def test_run(self):
+        num_steps = 1
+        data_shape = (1,)
+        send_data = np.ones(data_shape)
+
+        input_bridge = InputBridge(out_shape=data_shape)
+        recv = Recv(shape=data_shape)
+
+        input_bridge.out_port.connect(recv.in_port)
+
+        # run_condition has to be non-blocking in order to get past the call to run
+        run_condition = RunSteps(num_steps=num_steps, blocking=False)
+        run_cfg = Loihi2SimCfg(select_tag="floating_pt")
+
+        input_bridge.run(condition=run_condition, run_cfg=run_cfg)
+
+        input_bridge.send_data(send_data)
+
+        input_bridge.wait()
+
+        recv_data = recv.var.get()
+
+        input_bridge.stop()
+
+        np.testing.assert_equal(recv_data, send_data)
+
+
+class TestInputBridgeFixedPointProcessModel(unittest.TestCase):
+    def test_init(self):
+        out_shape = (1, )
+        recv_pipe, _ = mp.Pipe(duplex=False)
+        proc_params = {
+            "out_shape": out_shape,
+            "recv_pipe": recv_pipe
+        }
+
+        process_model = PyLoihiFixedPointInputBridgeProcessModel(proc_params=proc_params)
+
+        self.assertIsInstance(process_model, PyLoihiFixedPointInputBridgeProcessModel)
+        self.assertIsInstance(process_model._recv_pipe, mp.connection.PipeConnection)
+
+    def test_run(self):
+        num_steps = 1
+        data_shape = (1,)
+        send_data = np.ones(data_shape, dtype=int)
+
+        input_bridge = InputBridge(out_shape=data_shape)
+        recv = Recv(shape=data_shape)
+
+        input_bridge.out_port.connect(recv.in_port)
+
+        # run_condition has to be non-blocking in order to get past the call to run
+        run_condition = RunSteps(num_steps=num_steps, blocking=False)
+        run_cfg = Loihi2SimCfg(select_tag="fixed_pt")
+
+        input_bridge.run(condition=run_condition, run_cfg=run_cfg)
+
+        input_bridge.send_data(send_data)
+
+        input_bridge.wait()
+
+        recv_data = recv.var.get()
+
+        input_bridge.stop()
+
+        np.testing.assert_equal(recv_data, send_data)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/lava/proc/io/test_output_bridge.py
+++ b/tests/lava/proc/io/test_output_bridge.py
@@ -1,0 +1,211 @@
+import numpy as np
+import unittest
+import multiprocessing as mp
+
+from lava.magma.core.process.process import AbstractProcess
+from lava.magma.core.process.ports.ports import InPort, OutPort
+from lava.magma.core.process.variable import Var
+
+from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
+
+from lava.magma.core.decorator import implements, requires, tag
+from lava.magma.core.resources import CPU
+
+from lava.magma.core.model.py.model import PyLoihiProcessModel
+from lava.magma.core.model.py.type import LavaPyType
+from lava.magma.core.model.py.ports import PyInPort, PyOutPort
+
+from lava.magma.core.run_configs import Loihi2SimCfg
+from lava.magma.core.run_conditions import RunSteps, RunContinuous
+
+from lava.proc.io.output_bridge import OutputBridge, \
+    PyLoihiFloatingPointOutputBridgeProcessModel, \
+    PyLoihiFixedPointOutputBridgeProcessModel
+
+class Send(AbstractProcess):
+    """Process that sends arbitrary dense data.
+
+    Parameters
+    ----------
+    shape: tuple
+        Shape of the OutPort.
+    data: np.ndarray
+        Data to send through the OutPort.
+    """
+    def __init__(self, shape: tuple[...], data: np.ndarray) -> None:
+        super().__init__(shape=shape, data=data)
+
+        self.out_port = OutPort(shape=shape)
+
+
+@implements(proc=Send, protocol=LoihiProtocol)
+@requires(CPU)
+@tag("floating_pt")
+class PyLoihiFloatingPointSendProcessModel(PyLoihiProcessModel):
+    """Sends dense floating point data to PyOutPort."""
+    out_port: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, float)
+
+    def __init__(self, proc_params: dict):
+        super().__init__(proc_params)
+        self._data = proc_params["data"]
+
+    def run_spk(self) -> None:
+        self.out_port.send(data=self._data)
+
+
+@implements(proc=Send, protocol=LoihiProtocol)
+@requires(CPU)
+@tag("fixed_pt")
+class PyLoihiFixedPointSendProcessModel(PyLoihiProcessModel):
+    """Sends dense fixed point data to PyOutPort."""
+    out_port: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, int)
+
+    def __init__(self, proc_params: dict):
+        super().__init__(proc_params)
+        self._data = proc_params["data"]
+
+    def run_spk(self) -> None:
+        self.out_port.send(data=self._data)
+
+
+
+class TestOutputBridge(unittest.TestCase):
+    def test_init(self):
+        in_shape = (1, )
+
+        output_bridge = OutputBridge(in_shape=in_shape)
+
+        self.assertIsInstance(output_bridge, OutputBridge)
+        self.assertIsInstance(output_bridge._recv_pipe, mp.connection.PipeConnection)
+        self.assertIsInstance(output_bridge.proc_params["send_pipe"], mp.connection.PipeConnection)
+        self.assertEqual(output_bridge.in_port.shape, in_shape)
+
+    # TODO : Is this test really necessary ?
+    # def test_invalid_shape(self):
+    #     in_shape = (1.5, )
+    #
+    #     with self.assertRaises(ValueError):
+    #         OutputBridge(in_shape=in_shape)
+
+    def test_send_data(self):
+        in_shape = (1,)
+
+        output_bridge = OutputBridge(in_shape=in_shape)
+
+        send_data = np.ones(in_shape)
+        output_bridge.proc_params["send_pipe"].send(send_data)
+
+        recv_data = output_bridge.receive_data()
+
+        np.testing.assert_equal(recv_data, send_data)
+
+    def test_send_data_multiple_times_before_receiving(self):
+        # limit for (1, ) = 54
+        # limit for (2, ) = 52
+        # limit for (3, ) = 51
+
+        # limit for (4, ) = 50
+        # limit for (4,1) = 49
+        # limit for (2,2) = 49
+
+        # limit for (50, ) = 23
+        # limit for (50, 1) = 23
+        # limit for (5, 10) = 23
+
+        # limit for (100, ) = 14
+        # limit for (500, ) = 3
+        # limit for (986, ) = 2
+        # limit for (2010, ) = 1
+        # limit for (2011, ) = 0
+
+        num_consecutive_send_before_receive = 50
+        in_shape = (4, )
+
+        output_bridge = OutputBridge(in_shape=in_shape)
+
+        complete_send_data = [np.full(in_shape, i) for i in range(num_consecutive_send_before_receive)]
+
+        for send_data in complete_send_data:
+            output_bridge.proc_params["send_pipe"].send(send_data)
+
+        complete_recv_data = []
+
+        for _ in range(num_consecutive_send_before_receive):
+            complete_recv_data.append(output_bridge.receive_data())
+
+        np.testing.assert_equal(complete_recv_data, complete_send_data)
+
+
+class TestInputBridgeFloatingPointProcessModel(unittest.TestCase):
+    def test_init(self):
+        in_shape = (1, )
+        _, send_pipe = mp.Pipe(duplex=False)
+        proc_params = {
+            "out_shape": in_shape,
+            "send_pipe": send_pipe
+        }
+
+        process_model = PyLoihiFloatingPointOutputBridgeProcessModel(proc_params=proc_params)
+
+        self.assertIsInstance(process_model, PyLoihiFloatingPointOutputBridgeProcessModel)
+        self.assertIsInstance(process_model._send_pipe, mp.connection.PipeConnection)
+
+    def test_run(self):
+        num_steps = 1
+        data_shape = (1,)
+        send_data = np.ones(data_shape)
+
+        send = Send(shape=data_shape, data=send_data)
+        output_bridge = OutputBridge(in_shape=data_shape)
+
+        send.out_port.connect(output_bridge.in_port)
+
+        run_condition = RunSteps(num_steps=num_steps)
+        run_cfg = Loihi2SimCfg(select_tag="floating_pt")
+
+        send.run(condition=run_condition, run_cfg=run_cfg)
+
+        recv_data = output_bridge.receive_data()
+
+        send.stop()
+
+        np.testing.assert_equal(recv_data, send_data)
+
+
+class TestInputBridgeFixedPointProcessModel(unittest.TestCase):
+    def test_init(self):
+        in_shape = (1, )
+        _, send_pipe = mp.Pipe(duplex=False)
+        proc_params = {
+            "out_shape": in_shape,
+            "send_pipe": send_pipe
+        }
+
+        process_model = PyLoihiFixedPointOutputBridgeProcessModel(proc_params=proc_params)
+
+        self.assertIsInstance(process_model, PyLoihiFixedPointOutputBridgeProcessModel)
+        self.assertIsInstance(process_model._send_pipe, mp.connection.PipeConnection)
+
+    def test_run(self):
+        num_steps = 1
+        data_shape = (1,)
+        send_data = np.ones(data_shape, dtype=int)
+
+        send = Send(shape=data_shape, data=send_data)
+        output_bridge = OutputBridge(in_shape=data_shape)
+
+        send.out_port.connect(output_bridge.in_port)
+
+        run_condition = RunSteps(num_steps=num_steps)
+        run_cfg = Loihi2SimCfg(select_tag="fixed_pt")
+
+        send.run(condition=run_condition, run_cfg=run_cfg)
+
+        recv_data = output_bridge.receive_data()
+
+        send.stop()
+
+        np.testing.assert_equal(recv_data, send_data)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: Addition of IO bridge (Python only) Processes for getting input to/output from Lava.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
- [ ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [x] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [ ] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [ ] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [ ] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- At the moment, the only ways to get data into Lava, from a Python application, is to go through the `Dataloader` or `RingBuffer` Processes, or the `set()` method on Process `Var`.
  - The `Dataloader` Process keeps data in disk, and only loads portions of it step-by-step.
  - The `RingBuffer` Process loads all data to memory from the start.
  - The `set()` method requires running Lava workloads one time step at a time, and calling it between each `run()` call.
-  Similarly, the only ways to get data out of Lava, to use in a Python application, is to go through the `RingBuffer` Process, or the `get()` method on Process `Var`.
  - The `RingBuffer` Process buffers data in memory, and one has to call `get()` at the end of the run on its `data` `Var` to get the data out.
  - The `get()` method requires running Lava workloads one time step at a time, and calling it between each `run()` call.

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- With the `InputBridge` Process on the input side, users would be able to seamlessly integrate Lava workloads (running in non-blocking mode) into broader applications. These Lava workloads would be able to get **dynamically generated input data from Python applications, without having to pause and re-run every time step.**
  - "Dynamically generated input data" means: Without having to pre-load the data from the start (in contrast with the `RingBuffer` option).
  - "From Python applications" means: Not loading from disk (in contrast with the `Dataloader` option). 
  - "Without having to pause and re-run every time step" means: Lava workload won't have to run one time step at a time (in contrast with the `set()` option).
- With the `OutputBridge` Process on the output side, users would be able to seamlessly integrate Lava workloads (running in non-blocking mode) into broader applications. These broader applications would be able to get **real-time output data from Lava workloads, without having to pause and re-run every time step.**
  - "Real-time output data from Lava workloads" means: Without having to wait for a Lava run to finish to get data out (in contrast with the `RingBuffer` option).
  -  "Without having to pause and re-run every time step" means: Lava workload won't have to run one time step at a time (in contrast with the `get()` option).

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information
### TODO:
- Add `RefPortInputBridge` variant, which relays data from Python to Lava `RefPort`.
- Add `VarOutputBridge` variant, which relays data from Lava `Var` to Python.
- Add variants with `VEC_SPARSE` `InPort`, `OutPort`, `RefPort`.
  - **These would have to be new Processes, not ProcessModels.** 
- __(Uncertain)__ Add (or change to) `AsyncProcessModels`, implementing the `AsyncProtocol`.

### Open questions:
- Do we really need `AsyncProcessModels` ? If so, do we need to change the current `PyLoihiProcessModels` to Async ones or do we need to simply add Async ones ?
- Should we create new fully fledged Lava constructs to implement this, or is the simple use of `multiprocessing.Pipe` object enough ? How would that behave, and how much would we need to change, if we switch to a different message passing back-end ?
  - At the moment, usage of `multiprocessing.Pipe` is restricted to piping objects with a limited size (which is, it seems, variable, from one machine/OS to another). For instance, as an example, we cannot send `np.ndarray` of `float` `dtype` with more than 2010 items.
  - Not only this, but even with objects of smaller size, we are limited by the number of different objects we can send in a row without receiving on the receiving end.
  - This is due to the fact that `multiprocessing.Pipe` construct has a limited buffer size.
  **- How should we address this ?**

<!-- Any other information that is important to this PR. -->
