### PR TITLE
Minor refactoring for DelayDense/Sparse process

### DIFF
--- a/src/lava/proc/dense/process.py
+++ b/src/lava/proc/dense/process.py
@@ -232,17 +232,17 @@ class DelayDense(Dense):
             spikes as binary spikes (num_message_bits = 0) or as graded
             spikes (num_message_bits > 0). Default is 0.
         """
+        self._validate_delays(weights, delays)
+        shape = weights.shape
+        if max_delay == 0:
+            max_delay = int(np.max(delays))
 
         super().__init__(weights=weights,
                          num_message_bits=num_message_bits,
                          name=name,
                          log_config=log_config,
+                         max_delay=max_delay,
                          **kwargs)
-
-        self._validate_delays(weights, delays)
-        shape = weights.shape
-        if max_delay == 0:
-            max_delay = int(np.max(delays))
 
         # Variables
         self.delays = Var(shape=shape, init=delays)

--- a/src/lava/proc/dense/process.py
+++ b/src/lava/proc/dense/process.py
@@ -232,8 +232,6 @@ class DelayDense(Dense):
             spikes as binary spikes (num_message_bits = 0) or as graded
             spikes (num_message_bits > 0). Default is 0.
         """
-        self._validate_delays(weights, delays)
-        shape = weights.shape
         if max_delay == 0:
             max_delay = int(np.max(delays))
 
@@ -243,6 +241,9 @@ class DelayDense(Dense):
                          log_config=log_config,
                          max_delay=max_delay,
                          **kwargs)
+
+        self._validate_delays(weights, delays)
+        shape = weights.shape
 
         # Variables
         self.delays = Var(shape=shape, init=delays)

--- a/src/lava/proc/sparse/process.py
+++ b/src/lava/proc/sparse/process.py
@@ -245,17 +245,17 @@ class DelaySparse(Sparse):
             spikes as binary spikes (num_message_bits = 0) or as graded
             spikes (num_message_bits > 0). Default is 0.
         """
+        self._validate_delays(weights, delays)
+        shape = weights.shape
+        if max_delay == 0:
+            max_delay = int(np.max(delays))
 
         super().__init__(weights=weights,
                          num_message_bits=num_message_bits,
                          name=name,
                          log_config=log_config,
+                         max_delay=max_delay,
                          **kwargs)
-
-        self._validate_delays(weights, delays)
-        shape = weights.shape
-        if max_delay == 0:
-            max_delay = int(np.max(delays))
 
         # Variables
         self.delays = Var(shape=shape, init=delays)

--- a/src/lava/proc/sparse/process.py
+++ b/src/lava/proc/sparse/process.py
@@ -245,8 +245,6 @@ class DelaySparse(Sparse):
             spikes as binary spikes (num_message_bits = 0) or as graded
             spikes (num_message_bits > 0). Default is 0.
         """
-        self._validate_delays(weights, delays)
-        shape = weights.shape
         if max_delay == 0:
             max_delay = int(np.max(delays))
 
@@ -256,6 +254,9 @@ class DelaySparse(Sparse):
                          log_config=log_config,
                          max_delay=max_delay,
                          **kwargs)
+
+        self._validate_delays(weights, delays)
+        shape = weights.shape
 
         # Variables
         self.delays = Var(shape=shape, init=delays)


### PR DESCRIPTION
<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: The maximum delay needs to be part of the keyword arguments of the Dense process in order to use this value for the NcProcModel to determine the needed number of bits when configuring delays on Loihi 2.

This change does not affect anything else.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
- [ ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
- [ ] Tests are part of the PR (for bug fixes / features)
- [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
- [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
- [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
- [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
- [x] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
-

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
-

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
