### PR TITLE
Executable explicitly contains a flat list of *all* Processes after ProcGroups are created

### DIFF
--- a/src/lava/magma/compiler/compiler.py
+++ b/src/lava/magma/compiler/compiler.py
@@ -128,6 +128,8 @@ class Compiler:
         # ProcGroups.
         proc_group_digraph = ProcGroupDiGraphs(process, run_cfg)
         proc_groups: ty.List[ProcGroup] = proc_group_digraph.get_proc_groups()
+        # Get a flattened list of all AbstractProcesses
+        process_list = list(itertools.chain.from_iterable(proc_groups))
         channel_map = ChannelMap.from_proc_groups(proc_groups)
         proc_builders, channel_map = self._compile_proc_groups(
             proc_groups, channel_map
@@ -161,6 +163,7 @@ class Compiler:
 
         # Package all Builders and NodeConfigs into an Executable.
         executable = Executable(
+            process_list,
             proc_builders,
             channel_builders,
             node_configs,

--- a/src/lava/magma/compiler/executable.py
+++ b/src/lava/magma/compiler/executable.py
@@ -33,6 +33,7 @@ class Executable:
     # py_builders: ty.Dict[AbstractProcess, NcProcessBuilder]
     # c_builders: ty.Dict[AbstractProcess, CProcessBuilder]
     # nc_builders: ty.Dict[AbstractProcess, PyProcessBuilder]
+    process_list: ty.List[AbstractProcess]  # All leaf processes, flat list.
     proc_builders: ty.Dict[AbstractProcess, 'AbstractProcessBuilder']
     channel_builders: ty.List[ChannelBuilderMp]
     node_configs: ty.List[NodeConfig]
@@ -43,5 +44,5 @@ class Executable:
         ty.Iterable[AbstractChannelBuilder]] = None
 
     def assign_runtime_to_all_processes(self, runtime):
-        for p in self.proc_builders.keys():
+        for p in self.process_list:
             p.runtime = runtime

--- a/src/lava/utils/profiler.py
+++ b/src/lava/utils/profiler.py
@@ -18,27 +18,6 @@ except ModuleNotFoundError:
                   "Currently no profiler is available.")
 
 
-def get_pyobj_size(obj, seen=None):
-    """Recursively finds size of objects"""
-    size = sys.getsizeof(obj)
-    if seen is None:
-        seen = set()
-    obj_id = id(obj)
-    if obj_id in seen:
-        return 0
-    # Important mark as seen *before* entering recursion to gracefully handle
-    # self-referential objects
-    seen.add(obj_id)
-    if isinstance(obj, dict):
-        size += sum([get_pyobj_size(v, seen) for v in obj.values()])
-        size += sum([get_pyobj_size(k, seen) for k in obj.keys()])
-    elif hasattr(obj, '__dict__'):
-        size += get_pyobj_size(obj.__dict__, seen)
-    elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
-        size += sum([get_pyobj_size(i, seen) for i in obj])
-    return size
-
-
 class Profiler:
     """Base class for profiling execution time, energy and other
     metrics on different resources. Depending on the computing

--- a/src/lava/utils/profiler.py
+++ b/src/lava/utils/profiler.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # See: https://spdx.org/licenses/
 
-import sys
 import warnings
 import typing as ty
 from lava.magma.core.run_configs import RunConfig, Loihi2HwCfg

--- a/tests/lava/magma/runtime/test_runtime.py
+++ b/tests/lava/magma/runtime/test_runtime.py
@@ -27,7 +27,8 @@ class TestRuntime(unittest.TestCase):
 
     def test_executable_node_config_assertion(self):
         """Tests runtime constructions with expected constraints"""
-        exe: Executable = Executable(proc_builders={},
+        exe: Executable = Executable(process_list=[],
+                                     proc_builders={},
                                      channel_builders=[],
                                      node_configs=[],
                                      sync_domains=[])
@@ -45,7 +46,8 @@ class TestRuntime(unittest.TestCase):
             f"Expected type {expected_type} doesn't match {(type(runtime2))}")
         runtime2.stop()
 
-        exe1: Executable = Executable(proc_builders={},
+        exe1: Executable = Executable(process_list=[],
+                                      proc_builders={},
                                       channel_builders=[],
                                       node_configs=[],
                                       sync_domains=[])


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: N/A

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: Executable explicitly contains a flat list of *all* Processes after ProcGroups are created (all SubProcesses are resolved). This helps in propagating the Runtime to all Processes.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
-   [ ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [ ] Tests are part of the PR (for bug fixes / features)
-   [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [ ] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

-   [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- Currently, keys of ProcBuilders dict are used to assign Runtime to Processes. However, the keys of NcProcBuilders dict are only "neuron-like" Processes. Connection-like Processes are omitted from this dict. This resulted in not assigning any Runtime to connection-like Processes. Consequently, get/set doesn't work for Vars of such Processes.

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- A flat list of all Processes is stored in the Executable. When assigning Runtime, this list is iterated over. This way, no Process is left behind in assigning the Runtime.

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->