### PR TITLE
Fixing create_runtime unit test.

### DIFF
--- a/tests/lava/magma/core/process/test_process.py
+++ b/tests/lava/magma/core/process/test_process.py
@@ -8,7 +8,8 @@ from unittest.mock import Mock, seal
 import typing as ty
 from lava.magma.compiler.executable import Executable
 from lava.magma.core.decorator import implements, requires
-from lava.magma.core.model.py.model import AbstractPyProcessModel
+from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
+from lava.magma.core.model.py.model import PyLoihiProcessModel
 
 from lava.magma.core.process.ports.ports import (
     InPort,
@@ -26,7 +27,6 @@ from lava.magma.core.process.variable import Var
 from lava.magma.core.resources import CPU
 from lava.magma.core.run_conditions import RunSteps
 from lava.magma.core.run_configs import RunConfig
-from lava.magma.core.sync.protocol import AbstractSyncProtocol
 from lava.magma.runtime.runtime import Runtime
 
 
@@ -37,24 +37,10 @@ class MinimalProcess(AbstractProcess):
         super().__init__(name=name)
 
 
-class MinimalRuntimeService:
-    __name__ = 'MinimalRuntimeService'
-
-    def __init__(self):
-        pass
-
-
-class MinimalProtocol(AbstractSyncProtocol):
-    @property
-    def runtime_service(self):
-        return {CPU: MinimalRuntimeService()}
-
-
-@implements(proc=MinimalProcess, protocol=MinimalProtocol)
+@implements(proc=MinimalProcess, protocol=LoihiProtocol)
 @requires(CPU)
-class MinimalPyProcessModel(AbstractPyProcessModel):
-    def run(self):
-        raise NotImplementedError('This model doesnt run')
+class MinimalPyProcessModel(PyLoihiProcessModel):
+    pass
 
 
 class MinimalRunConfig(RunConfig):
@@ -319,7 +305,10 @@ class TestProcess(unittest.TestCase):
         self.assertTrue(r._is_initialized)
         self.assertFalse(r._is_started)
         self.assertFalse(r._is_running)
-
+        # HACK: Need to fix Issue #716 to avoid this.
+        p.run(condition=RunSteps(1), run_cfg=run_cfg)
+        p.stop()
+    
     def test_run_without_run_config_raises_error(self) -> None:
         """Tests whether an error is raised when run() is called on
         uncompiled Processes without specifying a RunConfig."""

--- a/tests/lava/magma/core/process/test_process.py
+++ b/tests/lava/magma/core/process/test_process.py
@@ -308,7 +308,7 @@ class TestProcess(unittest.TestCase):
         # HACK: Need to fix Issue #716 to avoid this.
         p.run(condition=RunSteps(1), run_cfg=run_cfg)
         p.stop()
-    
+
     def test_run_without_run_config_raises_error(self) -> None:
         """Tests whether an error is raised when run() is called on
         uncompiled Processes without specifying a RunConfig."""


### PR DESCRIPTION
## Issue
Issue Number: #717 

## Objective
Objective of pull request: Fixing create_runtime unit test.

## Pull request checklist
Your PR fulfills the following requirements:
-   [X] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [X] Tests are part of the PR (for bug fixes / features)
-   [X] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [X] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [X] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [X] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [X] Build tests (`pytest`) passes locally


## Pull request type
-   [X] Bugfix

## What is the current behavior?
- The unit test is failing due to an unimplemented method in a Mock object.

## What is the new behavior?
- The unit test is passing.

## Does this introduce a breaking change?
-   [X] No
