### PR TITLE
Fix partition parse bug for internal vLab

### DIFF
--- a/src/lava/utils/slurm.py
+++ b/src/lava/utils/slurm.py
@@ -118,14 +118,18 @@ def get_partitions() -> ty.List[PartitionInfo]:
 
     def parse_partition(line: str) -> PartitionInfo:
         fields = line.split()
-
-        return PartitionInfo(name=fields[0],
-                             available=fields[1],
-                             timelimit=fields[2],
-                             nodes=fields[3],
-                             state=fields[4],
-                             nodelist=fields[5])
-
+        name = fields[0]
+        avail = fields[1] if len(fields) > 1 else ''
+        limit = fields[2] if len(fields) > 2 else ''
+        nodes = fields[3] if len(fields) > 3 else ''
+        state = fields[4] if len(fields) > 4 else ''
+        nodel = fields[5] if len(fields) > 5 else ''
+        return PartitionInfo(name=name,
+                             available=avail,
+                             timelimit=limit,
+                             nodes=nodes,
+                             state=state,
+                             nodelist=nodel)
     return [parse_partition(line) for line in lines]
 
 

--- a/src/lava/utils/system.py
+++ b/src/lava/utils/system.py
@@ -10,12 +10,13 @@ from typing import Optional, Callable, TypeVar
 # so I'm adding it here to deprecate this module :/
 _T = TypeVar("_T")
 def deprecated(__msg: str) -> Callable[[_T], _T]:
-        def decorator(__arg: _T) -> _T:
-            __arg.__deprecated__ = __msg
-            return __arg
-        return decorator
+    def decorator(__arg: _T) -> _T:
+        __arg.__deprecated__ = __msg
+        return __arg
+    return decorator
 
 # NOTE: This module is deprecated as of v0.8.0 in favor of lava.utils.loihi
+
 
 class staticproperty(property):
     """Wraps static member function of a class as a static property of that
@@ -24,6 +25,7 @@ class staticproperty(property):
 
     def __get__(self, cls, owner):
         return staticmethod(self.fget).__get__(None, owner)()
+
 
 @deprecated('This class is deprecated. Use lava.utils.loihi instead.')
 class Loihi2:

--- a/src/lava/utils/system.py
+++ b/src/lava/utils/system.py
@@ -9,6 +9,8 @@ from typing import Optional, Callable, TypeVar
 # NOTE: Awkward, but the std lib deprecated decorator is not available yet,
 # so I'm adding it here to deprecate this module :/
 _T = TypeVar("_T")
+
+
 def deprecated(__msg: str) -> Callable[[_T], _T]:
     def decorator(__arg: _T) -> _T:
         __arg.__deprecated__ = __msg

--- a/src/lava/utils/system.py
+++ b/src/lava/utils/system.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+# See: https://spdx.org/licenses/
+
+import os
+
+from typing import Optional, Callable, TypeVar
+
+# NOTE: Awkward, but the std lib deprecated decorator is not available yet,
+# so I'm adding it here to deprecate this module :/
+_T = TypeVar("_T")
+def deprecated(__msg: str) -> Callable[[_T], _T]:
+        def decorator(__arg: _T) -> _T:
+            __arg.__deprecated__ = __msg
+            return __arg
+        return decorator
+
+# NOTE: This module is deprecated as of v0.8.0 in favor of lava.utils.loihi
+
+class staticproperty(property):
+    """Wraps static member function of a class as a static property of that
+    class.
+    """
+
+    def __get__(self, cls, owner):
+        return staticmethod(self.fget).__get__(None, owner)()
+
+@deprecated('This class is deprecated. Use lava.utils.loihi instead.')
+class Loihi2:
+    preferred_partition: str = None
+
+    @deprecated('This method is deprecated. Use lava.utils.loihi instead.')
+    @staticmethod
+    def set_environ_settings(partititon: Optional[str] = None) -> None:
+        """Sets the os environment for execution on Loihi.
+        Parameters
+        ----------
+        partititon : str, optional
+            Loihi partition name, by default None.
+        """
+        if 'SLURM' not in os.environ and 'NOSLURM' not in os.environ:
+            os.environ['SLURM'] = '1'
+        if 'LOIHI_GEN' not in os.environ:
+            os.environ['LOIHI_GEN'] = 'N3B3'
+        if 'PARTITION' not in os.environ and partititon is not None:
+            os.environ['PARTITION'] = partititon
+
+    @deprecated('This method is deprecated. Use lava.utils.loihi instead.')
+    @staticproperty
+    def is_loihi2_available() -> bool:
+        """Checks if Loihi2 compiler is available and sets the environment
+        vairables.
+        Returns
+        -------
+        bool
+            Flag indicating whether Loih 2 is available or not.
+        """
+        try:
+            from lava.magma.compiler.subcompilers.nc.ncproc_compiler import \
+                CompilerOptions
+            CompilerOptions.verbose = True
+        except ModuleNotFoundError:
+            # Loihi2 compiler is not availabe
+            return False
+        Loihi2.set_environ_settings(Loihi2.preferred_partition)
+        return True
+
+    @deprecated('This method is deprecated. Use lava.utils.loihi instead.')
+    @staticproperty
+    def partition():
+        """Get the partition information."""
+        if 'PARTITION' in os.environ.keys():
+            return os.environ['PARTITION']
+        return 'Unspecified'


### PR DESCRIPTION
Issue Number: #739 

Objective of pull request: Fixing a bug from earlier merge due to invalid partition rows in sinfo.

## Pull request checklist
Your PR fulfills the following requirements:
-   [X] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [X] Tests are part of the PR (for bug fixes / features)
-   [X] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [X] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [X] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [X] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [X] Build tests (`pytest`) passes locally


## Pull request type
-   [X] Bugfix


## What is the current behavior?
- lava.utils.slurm produces errors when run on internal vLab due to missing nodelist field in sinfo.

## What is the new behavior?
- No error will be produced, a default value (empty string) will be returned in PartitionInfo.

## Does this introduce a breaking change?
-   [X] No
