### PR TITLE
Add loglevel to PyLoihiProcessModel.__init__

### DIFF
--- a/src/lava/magma/core/model/py/model.py
+++ b/src/lava/magma/core/model/py/model.py
@@ -282,8 +282,9 @@ class PyLoihiProcessModel(AbstractPyProcessModel):
 
     """
 
-    def __init__(self, proc_params: ty.Optional["ProcessParameters"] = None):
-        super().__init__(proc_params=proc_params)
+    def __init__(self, proc_params: ty.Optional["ProcessParameters"] = None,
+                 loglevel: ty.Optional[int] = logging.WARNING):
+        super().__init__(proc_params=proc_params, loglevel=loglevel)
         self.time_step = 0
         self.phase = PyLoihiProcessModel.Phase.SPK
         self._cmd_handlers.update(


### PR DESCRIPTION
Issue Number: #760 

Objective of pull request: Add loglevel paramater to PyLoihiProcessModel constructor

## Pull request checklist
Your PR fulfills the following requirements:
-   [X] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [X] Tests are part of the PR (for bug fixes / features)
-   [X] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [X] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [X] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [X] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [X] Build tests (`pytest`) passes locally

## Pull request type
Please check your PR type:
-   [X] Bugfix

## What is the current behavior?
- User cannot override the default loglevel of a PyLoihiProcessModel.

## What is the new behavior?
- User can provide a loglevel parameter to the PyLoihiProcessModel constructor which will be forwarded to the AbstractPyProcessModel constructor, leading to a different loglevel being set for the process model log.

## Does this introduce a breaking change?
-   [X] No
