### PR TITLE
Enable int or None as run_condition for Process.run and Runtime.start

### DIFF
--- a/src/lava/magma/core/process/process.py
+++ b/src/lava/magma/core/process/process.py
@@ -304,7 +304,7 @@ class AbstractProcess(metaclass=ProcessPostInitCaller):
             return False
 
     def run(self,
-            condition: AbstractRunCondition,
+            condition: ty.Optional[ty.Union[AbstractRunCondition, int]],
             run_cfg: ty.Optional[RunConfig] = None,
             compile_config: ty.Optional[ty.Dict[str, ty.Any]] = None):
         """Executes this and any connected Processes that form a Process
@@ -333,8 +333,10 @@ class AbstractProcess(metaclass=ProcessPostInitCaller):
 
         Parameters
         ----------
-        condition : AbstractRunCondition
-            Specifies for how long to run the Process.
+        condition : Optional[Union[AbstractRunCondition, int]], default=None
+            The condition that determines how long to run the process. If
+            condition is an int, runs for the specified number of timesteps.
+            If condition is None, runs until paused or stopped.
         run_cfg : RunConfig, optional
             Used by the compiler to select a ProcessModel for each Process.
             Must be provided when Processes have to be compiled, can be

--- a/src/lava/magma/runtime/runtime.py
+++ b/src/lava/magma/runtime/runtime.py
@@ -327,16 +327,27 @@ class Runtime:
                     self._is_running = False
                     return
 
-    def start(self, run_condition: AbstractRunCondition):
+    def start(self, run_condition:
+              ty.Optional[ty.Union[AbstractRunCondition, int]] = None):
         """
-        Given a run condition, starts the runtime
-
-        :param run_condition: AbstractRunCondition
-        :return: None
+        Start the runtime and run as long as the run_condition dictates.
+        Parameters
+        ----------
+        run_condition : Optional[Union[AbstractRunCondition, int]],
+            default = None
+            The condition specifying how long to run the runtime. If
+            run_condition is an int, the runtime will create a RunSteps
+            condition and run for the number of timesteps. If
+            run_condition is None (default), runtime will create a
+            RunContinuous condition and run until interrupted.
         """
         if self._is_initialized:
             # Start running
             self._is_started = True
+            if run_condition is None:
+                run_condition = RunContinuous()
+            elif isinstance(run_condition, int):
+                run_condition = RunSteps(run_condition)
             self._run(run_condition)
         else:
             self.log.info("Runtime not initialized yet.")

--- a/tests/lava/magma/runtime/test_runtime.py
+++ b/tests/lava/magma/runtime/test_runtime.py
@@ -21,7 +21,7 @@ from lava.proc.io.sink import RingBuffer as SinkBuffer
 
 
 def setup_condition_test():
-    source = SourceBuffer(data=np.array(range(1000)).reshape((1,-1)))
+    source = SourceBuffer(data=np.array(range(1000)).reshape((1, -1)))
     sink = SinkBuffer(shape=(1,), buffer=10)
     source.s_out.connect(sink.a_in)
     source.create_runtime(run_cfg=Loihi2SimCfg())


### PR DESCRIPTION
Issue Number: #768 

Objective of pull request: Add logic to create a RunSteps or RunContinuous in Runtime.start when user passes an int or None respectively. This allows users to just call process.run(5) or process.run() and get useful behavior, rather than always importing RunSteps/RunContinuous.

## Pull request checklist
Your PR fulfills the following requirements:
-   [X] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [X] Tests are part of the PR (for bug fixes / features)
-   [X] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [X] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [X] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [X] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [X] Build tests (`pytest`) passes locally

## Pull request type
Please check your PR type:
-   [X] Feature

## What is the current behavior?
- User must always explicitly create an instance of AbstractRunCondition.

## What is the new behavior?
- Runtime.start will implicitly create a RunSteps or RunContinuous if condition is an int or None.

## Does this introduce a breaking change?
-   [X] No
