### PR TITLE
Allow np.array as input weights for Sparse

### DIFF
--- a/src/lava/proc/sparse/process.py
+++ b/src/lava/proc/sparse/process.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2021-23 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 # See: https://spdx.org/licenses/
-from abc import abstractmethod
 
 import numpy as np
 from scipy.sparse import spmatrix, csr_matrix

--- a/src/lava/proc/sparse/process.py
+++ b/src/lava/proc/sparse/process.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021-23 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 # See: https://spdx.org/licenses/
+from abc import abstractmethod
 
 import numpy as np
 from scipy.sparse import spmatrix, csr_matrix
@@ -55,6 +56,7 @@ class Sparse(AbstractProcess):
         spikes as binary spikes (num_message_bits = 0) or as graded
         spikes (num_message_bits > 0). Default is 0.
         """
+
     def __init__(self,
                  *,
                  weights: ty.Union[spmatrix, np.ndarray],
@@ -68,12 +70,7 @@ class Sparse(AbstractProcess):
                          log_config=log_config,
                          **kwargs)
 
-        # Transform weights to csr matrix
-        if isinstance(weights, np.ndarray):
-            weights = csr_matrix(weights)
-        else:
-            weights = weights.tocsr()
-
+        weights = self._create_csr_matrix_from_weights(weights)
         shape = weights.shape
 
         # Ports
@@ -84,6 +81,15 @@ class Sparse(AbstractProcess):
         self.weights = Var(shape=shape, init=weights)
         self.a_buff = Var(shape=(shape[0],), init=0)
         self.num_message_bits = Var(shape=(1,), init=num_message_bits)
+
+    @staticmethod
+    def _create_csr_matrix_from_weights(weights):
+        # Transform weights to csr matrix
+        if isinstance(weights, np.ndarray):
+            weights = csr_matrix(weights)
+        else:
+            weights = weights.tocsr()
+        return weights
 
 
 class LearningSparse(LearningConnectionProcess, Sparse):
@@ -151,6 +157,7 @@ class LearningSparse(LearningConnectionProcess, Sparse):
         x1 and regular impulse addition to x2 will be considered by the
         learning rule Products conditioned on x0.
         """
+
     def __init__(self,
                  *,
                  weights: ty.Union[spmatrix, np.ndarray],
@@ -174,12 +181,7 @@ class LearningSparse(LearningConnectionProcess, Sparse):
                          graded_spike_cfg=graded_spike_cfg,
                          **kwargs)
 
-        # Transform weights to csr matrix
-        if isinstance(weights, np.ndarray):
-            weights = csr_matrix(weights)
-        else:
-            weights = weights.tocsr()
-
+        weights = self._create_csr_matrix_from_weights(weights)
         shape = weights.shape
 
         # Ports

--- a/src/lava/proc/sparse/process.py
+++ b/src/lava/proc/sparse/process.py
@@ -3,7 +3,7 @@
 # See: https://spdx.org/licenses/
 
 import numpy as np
-from scipy.sparse import spmatrix
+from scipy.sparse import spmatrix, csr_matrix
 import typing as ty
 
 from lava.magma.core.process.process import AbstractProcess, LogConfig
@@ -21,7 +21,8 @@ class Sparse(AbstractProcess):
 
     Parameters
     ----------
-    weights : scipy.sparse.spmatrix
+    weights : scipy.sparse.spmatrix or np.ndarray
+        both get directly converted to a csr_matrix
         2D connection weight matrix as sparse matrix of form
         (num_flat_output_neurons, num_flat_input_neurons).
 
@@ -57,7 +58,7 @@ class Sparse(AbstractProcess):
         """
     def __init__(self,
                  *,
-                 weights: spmatrix,
+                 weights: ty.Union[spmatrix, np.ndarray],
                  name: ty.Optional[str] = None,
                  num_message_bits: ty.Optional[int] = 0,
                  log_config: ty.Optional[LogConfig] = None,
@@ -69,7 +70,10 @@ class Sparse(AbstractProcess):
                          **kwargs)
 
         # Transform weights to csr matrix
-        weights = weights.tocsr()
+        if type(weights) == np.ndarray:
+            weights = csr_matrix(weights)
+        else:
+            weights = weights.tocsr()
 
         shape = weights.shape
 
@@ -90,7 +94,8 @@ class LearningSparse(LearningConnectionProcess, Sparse):
 
     Parameters
     ----------
-    weights : scipy.sparse.spmatrix
+    weights : scipy.sparse.spmatrix or np.ndarray
+        both get directly converted to a csr_matrix
         2D connection weight matrix as sparse matrix of form
         (num_flat_output_neurons, num_flat_input_neurons).
 
@@ -150,7 +155,7 @@ class LearningSparse(LearningConnectionProcess, Sparse):
         """
     def __init__(self,
                  *,
-                 weights: spmatrix,
+                 weights: ty.Union[spmatrix, np.ndarray],
                  name: ty.Optional[str] = None,
                  num_message_bits: ty.Optional[int] = 0,
                  log_config: ty.Optional[LogConfig] = None,
@@ -172,7 +177,10 @@ class LearningSparse(LearningConnectionProcess, Sparse):
                          **kwargs)
 
         # Transform weights to csr matrix
-        weights = weights.tocsr()
+        if type(weights) == np.ndarray:
+            weights = csr_matrix(weights)
+        else:
+            weights = weights.tocsr()
 
         shape = weights.shape
 
@@ -189,7 +197,7 @@ class LearningSparse(LearningConnectionProcess, Sparse):
 class DelaySparse(Sparse):
     def __init__(self,
                  *,
-                 weights: spmatrix,
+                 weights: ty.Union[spmatrix, np.ndarray],
                  delays: ty.Union[spmatrix, int],
                  max_delay: ty.Optional[int] = 0,
                  name: ty.Optional[str] = None,
@@ -201,7 +209,8 @@ class DelaySparse(Sparse):
 
         Parameters
         ----------
-        weights : spmatrix
+        weights : scipy.sparse.spmatrix or np.ndarray
+            both get directly converted to a csr_matrix
             2D connection weight matrix of form (num_flat_output_neurons,
             num_flat_input_neurons) in C-order (row major).
 

--- a/src/lava/proc/sparse/process.py
+++ b/src/lava/proc/sparse/process.py
@@ -22,7 +22,6 @@ class Sparse(AbstractProcess):
     Parameters
     ----------
     weights : scipy.sparse.spmatrix or np.ndarray
-        both get directly converted to a csr_matrix
         2D connection weight matrix of form
         (num_flat_output_neurons, num_flat_input_neurons).
 
@@ -95,7 +94,6 @@ class LearningSparse(LearningConnectionProcess, Sparse):
     Parameters
     ----------
     weights : scipy.sparse.spmatrix or np.ndarray
-        both get directly converted to a csr_matrix
         2D connection weight matrix of form
         (num_flat_output_neurons, num_flat_input_neurons).
 
@@ -210,7 +208,6 @@ class DelaySparse(Sparse):
         Parameters
         ----------
         weights : scipy.sparse.spmatrix or np.ndarray
-            both get directly converted to a csr_matrix
             2D connection weight matrix of form (num_flat_output_neurons,
             num_flat_input_neurons) in C-order (row major).
 

--- a/src/lava/proc/sparse/process.py
+++ b/src/lava/proc/sparse/process.py
@@ -23,7 +23,7 @@ class Sparse(AbstractProcess):
     ----------
     weights : scipy.sparse.spmatrix or np.ndarray
         both get directly converted to a csr_matrix
-        2D connection weight matrix as sparse matrix of form
+        2D connection weight matrix of form
         (num_flat_output_neurons, num_flat_input_neurons).
 
     weight_exp : int, optional
@@ -96,7 +96,7 @@ class LearningSparse(LearningConnectionProcess, Sparse):
     ----------
     weights : scipy.sparse.spmatrix or np.ndarray
         both get directly converted to a csr_matrix
-        2D connection weight matrix as sparse matrix of form
+        2D connection weight matrix of form
         (num_flat_output_neurons, num_flat_input_neurons).
 
     weight_exp : int, optional

--- a/src/lava/proc/sparse/process.py
+++ b/src/lava/proc/sparse/process.py
@@ -70,7 +70,7 @@ class Sparse(AbstractProcess):
                          **kwargs)
 
         # Transform weights to csr matrix
-        if type(weights) == np.ndarray:
+        if isinstance(weights, np.ndarray):
             weights = csr_matrix(weights)
         else:
             weights = weights.tocsr()
@@ -177,7 +177,7 @@ class LearningSparse(LearningConnectionProcess, Sparse):
                          **kwargs)
 
         # Transform weights to csr matrix
-        if type(weights) == np.ndarray:
+        if isinstance(weights, np.ndarray):
             weights = csr_matrix(weights)
         else:
             weights = weights.tocsr()

--- a/tests/lava/proc/sparse/test_process.py
+++ b/tests/lava/proc/sparse/test_process.py
@@ -40,7 +40,6 @@ class TestSparseProcess(unittest.TestCase):
 
         conn = Sparse(weights=weights_sparse)
 
-        self.assertIsInstance(conn.weights.init, spmatrix)
         np.testing.assert_array_equal(conn.weights.init.toarray(), weights)
 
 
@@ -71,7 +70,6 @@ class TestLearningSparseProcess(unittest.TestCase):
         conn = LearningSparse(weights=weights_sparse,
                               learning_rule=learning_rule)
 
-        self.assertIsInstance(conn.weights.init, spmatrix)
         np.testing.assert_array_equal(conn.weights.init.toarray(), weights)
 
 
@@ -94,7 +92,6 @@ class TestDelaySparseProcess(unittest.TestCase):
 
         conn = DelaySparse(weights=weights_sparse, delays=delays_sparse)
 
-        self.assertIsInstance(conn.weights.init, spmatrix)
         np.testing.assert_array_equal(conn.weights.init.toarray(), weights)
 
     def test_validate_shapes(self):
@@ -132,20 +129,20 @@ class TestDelaySparseProcess(unittest.TestCase):
                                  weights=weights_sparse,
                                  delays=delays_sparse)
 
-    def test_ndarray_gets_converted_into_sparse(self):
-        """Tests if ndarray weights get converted to a spmatrix"""
+    def test_init_of_sparse_with_ndarray(self):
+        """Tests instantiation of Sparse with ndarray as
+         weights"""
 
         shape = (3, 2)
         weights = np.random.random(shape)
 
         conn = Sparse(weights=weights)
 
-        self.assertIsInstance(conn.weights.get(), spmatrix)
         np.testing.assert_array_equal(conn.weights.get().toarray(), weights)
 
-    def test_ndarray_gets_converted_into_sparse_for_learning(self):
-        """Tests if ndarray weights get converted to a spmatrix for
-        LearingSparse"""
+    def test_init_of_learningsparse_with_ndarray(self):
+        """Tests instantiation of LearningSparse with
+        ndarray as weights"""
 
         shape = (3, 2)
         weights = np.random.random(shape)
@@ -161,12 +158,10 @@ class TestDelaySparseProcess(unittest.TestCase):
 
         conn = LearningSparse(weights=weights, learning_rule=learning_rule)
 
-        self.assertIsInstance(conn.weights.get(), spmatrix)
         np.testing.assert_array_equal(conn.weights.get().toarray(), weights)
 
-    def test_ndarray_gets_converted_into_sparse_for_delay(self):
-        """Tests if ndarray weights get converted to a spmatrix for
-        DelaySparse"""
+    def test_init_of_delaysparse_with_ndarray(self):
+        """Tests instantiation of DelaySparse with ndarray as weights"""
 
         shape = (3, 2)
         weights = np.random.random(shape)
@@ -174,7 +169,6 @@ class TestDelaySparseProcess(unittest.TestCase):
 
         conn = DelaySparse(weights=weights, delays=delays)
 
-        self.assertIsInstance(conn.weights.get(), spmatrix)
         np.testing.assert_array_equal(conn.weights.get().toarray(), weights)
 
 

--- a/tests/lava/proc/sparse/test_process.py
+++ b/tests/lava/proc/sparse/test_process.py
@@ -42,6 +42,17 @@ class TestSparseProcess(unittest.TestCase):
 
         np.testing.assert_array_equal(conn.weights.init.toarray(), weights)
 
+    def test_init_of_sparse_with_ndarray(self):
+        """Tests instantiation of Sparse with ndarray as
+         weights"""
+
+        shape = (3, 2)
+        weights = np.random.random(shape)
+
+        conn = Sparse(weights=weights)
+
+        np.testing.assert_array_equal(conn.weights.get().toarray(), weights)
+
 
 class TestLearningSparseProcess(unittest.TestCase):
     """Tests for LearningSparse class"""
@@ -71,6 +82,26 @@ class TestLearningSparseProcess(unittest.TestCase):
                               learning_rule=learning_rule)
 
         np.testing.assert_array_equal(conn.weights.init.toarray(), weights)
+
+    def test_init_of_learningsparse_with_ndarray(self):
+        """Tests instantiation of LearningSparse with
+        ndarray as weights"""
+
+        shape = (3, 2)
+        weights = np.random.random(shape)
+
+        learning_rule = STDPLoihi(
+            learning_rate=1,
+            A_plus=1,
+            A_minus=-2,
+            tau_plus=10,
+            tau_minus=10,
+            t_epoch=2,
+        )
+
+        conn = LearningSparse(weights=weights, learning_rule=learning_rule)
+
+        np.testing.assert_array_equal(conn.weights.get().toarray(), weights)
 
 
 class TestDelaySparseProcess(unittest.TestCase):
@@ -128,37 +159,6 @@ class TestDelaySparseProcess(unittest.TestCase):
                                  DelaySparse,
                                  weights=weights_sparse,
                                  delays=delays_sparse)
-
-    def test_init_of_sparse_with_ndarray(self):
-        """Tests instantiation of Sparse with ndarray as
-         weights"""
-
-        shape = (3, 2)
-        weights = np.random.random(shape)
-
-        conn = Sparse(weights=weights)
-
-        np.testing.assert_array_equal(conn.weights.get().toarray(), weights)
-
-    def test_init_of_learningsparse_with_ndarray(self):
-        """Tests instantiation of LearningSparse with
-        ndarray as weights"""
-
-        shape = (3, 2)
-        weights = np.random.random(shape)
-
-        learning_rule = STDPLoihi(
-            learning_rate=1,
-            A_plus=1,
-            A_minus=-2,
-            tau_plus=10,
-            tau_minus=10,
-            t_epoch=2,
-        )
-
-        conn = LearningSparse(weights=weights, learning_rule=learning_rule)
-
-        np.testing.assert_array_equal(conn.weights.get().toarray(), weights)
 
     def test_init_of_delaysparse_with_ndarray(self):
         """Tests instantiation of DelaySparse with ndarray as weights"""

--- a/tests/lava/proc/sparse/test_process.py
+++ b/tests/lava/proc/sparse/test_process.py
@@ -15,7 +15,6 @@ class TestFunctions(unittest.TestCase):
     """Test helper function for Sparse"""
 
     def test_find_with_explicit_zeros(self):
-
         mat = np.random.randint(-10, 10, (3, 5))
         spmat = csr_matrix(mat)
         spmat.data[0] = 0
@@ -132,3 +131,52 @@ class TestDelaySparseProcess(unittest.TestCase):
                                  DelaySparse,
                                  weights=weights_sparse,
                                  delays=delays_sparse)
+
+    def test_ndarray_gets_converted_into_sparse(self):
+        """Tests if ndarray weights get converted to a spmatrix"""
+
+        shape = (3, 2)
+        weights = np.random.random(shape)
+
+        conn = Sparse(weights=weights)
+
+        self.assertIsInstance(conn.weights.get(), spmatrix)
+        np.testing.assert_array_equal(conn.weights.get().toarray(), weights)
+
+    def test_ndarray_gets_converted_into_sparse_for_learning(self):
+        """Tests if ndarray weights get converted to a spmatrix for
+        LearingSparse"""
+
+        shape = (3, 2)
+        weights = np.random.random(shape)
+
+        learning_rule = STDPLoihi(
+            learning_rate=1,
+            A_plus=1,
+            A_minus=-2,
+            tau_plus=10,
+            tau_minus=10,
+            t_epoch=2,
+        )
+
+        conn = LearningSparse(weights=weights, learning_rule=learning_rule)
+
+        self.assertIsInstance(conn.weights.get(), spmatrix)
+        np.testing.assert_array_equal(conn.weights.get().toarray(), weights)
+
+    def test_ndarray_gets_converted_into_sparse_for_delay(self):
+        """Tests if ndarray weights get converted to a spmatrix for
+        DelaySparse"""
+
+        shape = (3, 2)
+        weights = np.random.random(shape)
+        delays = np.random.randint(0, 3, shape)
+
+        conn = DelaySparse(weights=weights, delays=delays)
+
+        self.assertIsInstance(conn.weights.get(), spmatrix)
+        np.testing.assert_array_equal(conn.weights.get().toarray(), weights)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Objective of pull request: Allow np.array as input weights for Sparse

## Pull request checklist
Your PR fulfills the following requirements:
-   [ ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [x] Tests are part of the PR (for bug fixes / features)
-   [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [x] Build tests (`pytest`) passes locally


## Pull request type

Please check your PR type:
-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation changes
-   [ ] Other (please describe): 

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

-   [ ] Yes
-   [x] No