### PR TITLE
Add BitCheck Process

### DIFF
--- a/src/lava/magma/compiler/builders/channel_builder.py
+++ b/src/lava/magma/compiler/builders/channel_builder.py
@@ -30,15 +30,29 @@ PortInitializers = ty.Tuple[PortInitializer, PortInitializer]
 
 
 class WatchdogEnabledMixin:
+    SEND = "send"
+    RECV = "recv"
+    JOIN = "join"
+
     @staticmethod
     def watch(watchdog_manager: WatchdogManager,
               queue: Queue,
               process: "AbstractProcess",
+              other_process: "AbstractProcess",
               pi: PortInitializer,
+              other_pi: PortInitializer,
               method_type: str) -> Watchdog:
         process_cls: str = process.__class__.__name__
         port_name: str = pi.name
         name: str = f"{process_cls}.{port_name}"
+        if other_process and other_pi:
+            other_process_cls: str = other_process.__class__.__name__
+            other_port_name: str = other_pi.name
+            other_name: str = f"{other_process_cls}.{other_port_name}"
+            if method_type is WatchdogEnabledMixin.SEND:
+                name += f"->{other_name}"
+            elif method_type is WatchdogEnabledMixin.RECV:
+                name = f"{other_name}->{name}"
         w: Watchdog = watchdog_manager.create_watchdog(queue=queue,
                                                        channel_name=name,
                                                        method_type=method_type)
@@ -49,21 +63,33 @@ class WatchdogEnabledMixin:
                          queues: Queues,
                          port_initializers: PortInitializers) -> Watchdogs:
         src_send_watchdog: Watchdog = self.watch(watchdog_manager,
-                                                 queues[0], self.src_process,
+                                                 queues[0],
+                                                 self.src_process,
+                                                 self.dst_process,
                                                  port_initializers[0],
-                                                 "send")
+                                                 port_initializers[1],
+                                                 WatchdogEnabledMixin.SEND)
         src_join_watchdog: Watchdog = self.watch(watchdog_manager,
-                                                 queues[1], self.src_process,
+                                                 queues[1],
+                                                 self.src_process,
+                                                 self.dst_process,
                                                  port_initializers[0],
-                                                 "join")
+                                                 port_initializers[1],
+                                                 WatchdogEnabledMixin.JOIN)
         dst_recv_watchdog: Watchdog = self.watch(watchdog_manager,
-                                                 queues[2], self.dst_process,
+                                                 queues[2],
+                                                 self.dst_process,
+                                                 self.src_process,
                                                  port_initializers[1],
-                                                 "recv")
+                                                 port_initializers[0],
+                                                 WatchdogEnabledMixin.RECV)
         dst_join_watchdog: Watchdog = self.watch(watchdog_manager,
-                                                 queues[3], self.dst_process,
+                                                 queues[3],
+                                                 self.dst_process,
+                                                 self.src_process,
                                                  port_initializers[1],
-                                                 "join")
+                                                 port_initializers[0],
+                                                 WatchdogEnabledMixin.JOIN)
         return (src_send_watchdog, src_join_watchdog,
                 dst_recv_watchdog, dst_join_watchdog)
 

--- a/src/lava/magma/core/process/variable.py
+++ b/src/lava/magma/core/process/variable.py
@@ -48,6 +48,7 @@ class Var(AbstractProcessMember):
         shape: ty.Tuple[int, ...],
         init: ty.Union[bool, float, list, tuple, np.ndarray] = 0,
         shareable: bool = True,
+        name: str = "Unnamed variable",
     ):
         """Initializes a new Lava variable.
 
@@ -61,8 +62,8 @@ class Var(AbstractProcessMember):
         super().__init__(shape)
         self.init = init
         self.shareable = shareable
+        self.name = name
         self.id: int = VarServer().register(self)
-        self.name: str = "Unnamed variable"
         self.aliased_var: ty.Optional[Var] = None
         # VarModel generated during compilation
         self._model: ty.Optional["AbstractVarModel"] = None

--- a/src/lava/proc/bit_check/models.py
+++ b/src/lava/proc/bit_check/models.py
@@ -16,7 +16,7 @@ from lava.proc.bit_check.process import BitCheck
 
 
 class AbstractPyBitCheckModel(PyLoihiProcessModel):
-    """Abstract implementation of BitCheckModel
+    """Abstract implementation of BitCheckModel.
 
     Specific implementations inherit from here.
     """
@@ -32,7 +32,7 @@ class AbstractBitCheckModel(AbstractPyBitCheckModel):
     """Abstract implementation of BitCheck process. This
     short and simple ProcessModel can be used for quick
     checking of bit-accurate process runs as to whether
-    bits will overflow when running on hardware.
+    bits will overflow when running on bit limited hardware.
     """
 
     state: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
@@ -83,8 +83,8 @@ class AbstractBitCheckModel(AbstractPyBitCheckModel):
     def check_bit_overflow(self, value: ty.Type[np.ndarray]):
         value = value.astype(np.int32)
         shift_amt = 32 - self.bits
-        # shift value left by shift_amt and
-        # then shift value right by shift_amt
+        # Shift value left by shift_amt and
+        # then shift value right by shift_amt,
         # the result should equal unshifted value
         # if the value did not overflow bits in self.bits
         return not np.all(

--- a/src/lava/proc/bit_check/models.py
+++ b/src/lava/proc/bit_check/models.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+# See: https://spdx.org/licenses/
+
+import numpy as np
+import typing as ty
+
+from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
+from lava.magma.core.model.py.ports import PyRefPort
+from lava.magma.core.model.py.type import LavaPyType
+from lava.magma.core.resources import CPU
+from lava.magma.core.decorator import implements, requires
+from lava.magma.core.model.py.model import PyLoihiProcessModel
+
+from lava.proc.bit_check.process import BitCheck
+
+
+class AbstractPyBitCheckModel (PyLoihiProcessModel):
+    """Abstract implementation of BitCheckModel
+    
+    Specific implementations inherit from here.
+    """
+    ref: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
+
+    bits: int = LavaPyType(int, int)
+    layerid: int = LavaPyType(int, int)
+    debug: int = LavaPyType(int, int)
+
+
+class AbstractBitCheckModel (AbstractPyBitCheckModel):
+    """Abstract implementation of BitCheck process. This short and simple ProcessModel can be used 
+    for quick checking of bit-accurate process runs as to whether bits will overflow when 
+    running on hardware.
+    """
+
+    ref: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
+
+    bits: int = LavaPyType(int, int)
+    layerid: int = LavaPyType(int, int)
+    debug: int = LavaPyType(int, int)
+    _overflowed: int = LavaPyType(int, int)
+
+    def post_guard(self):
+        return True
+
+    def run_post_mgmt(self):
+        value = self.ref.read()
+
+        if self.debug == 1:
+            print("Value is: {} at time step: {}".format(
+                value,
+                self.time_step
+                )
+            )
+        
+        # If self.check_bit_overflow(value) is true,
+        # the value overflowed the allowed bits from self.bits
+        if self.check_bit_overflow(value):
+            self._overflowed = 1
+            if self.debug == 1:
+                if self.layerid:
+                    print("layer id number: {}".format(self.layerid))
+                print("value.max: overflows {} bits {}"
+                      .format(self.bits, value.max()))
+                print("max signed value {}"
+                      .format(self.max_signed_int_per_bits(self.bits)))
+                print("value.min: overflows {} bits {}"
+                      .format(self.bits, value.min()))
+                print("min signed value {}"
+                      .format(self.max_signed_int_per_bits(self.bits)))
+
+    def check_bit_overflow(self, value: ty.Type[np.ndarray]):
+        value = value.astype(np.int32)
+        shift_amt = 32 - self.bits
+        # shift value left by shift_amt and 
+        # then shift value right by shift_amt
+        # the result should equal unshifted value
+        # if the value did not overflow bits in self.bits
+        return not np.all(((value << shift_amt) >> shift_amt) == value)
+    
+    def max_unsigned_int_per_bits(bits):
+        return (1 << bits) - 1
+    
+    def min_signed_int_per_bits(bits):
+        return -1 << (bits - 1)
+    
+    def max_signed_int_per_bits(bits):
+        return (1 << (bits -1)) - 1
+
+
+@implements(proc=BitCheck, protocol=LoihiProtocol)
+@requires(CPU)
+class LoihiBitCheckModel (AbstractBitCheckModel):
+    """Implementation of Loihi BitCheck process. This short and simple ProcessModel can be used 
+    for quick checking of Loihi bit-accurate process run as to whether bits will overflow when 
+    running on Loihi Hardware.
+    """
+
+    ref: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
+
+    bits: int = LavaPyType(int, int)
+    layerid: int = LavaPyType(int, int)
+    debug: int = LavaPyType(int, int)

--- a/src/lava/proc/bit_check/models.py
+++ b/src/lava/proc/bit_check/models.py
@@ -15,11 +15,12 @@ from lava.magma.core.model.py.model import PyLoihiProcessModel
 from lava.proc.bit_check.process import BitCheck
 
 
-class AbstractPyBitCheckModel (PyLoihiProcessModel):
+class AbstractPyBitCheckModel(PyLoihiProcessModel):
     """Abstract implementation of BitCheckModel
-    
+
     Specific implementations inherit from here.
     """
+
     ref: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
 
     bits: int = LavaPyType(int, int)
@@ -27,10 +28,11 @@ class AbstractPyBitCheckModel (PyLoihiProcessModel):
     debug: int = LavaPyType(int, int)
 
 
-class AbstractBitCheckModel (AbstractPyBitCheckModel):
-    """Abstract implementation of BitCheck process. This short and simple ProcessModel can be used 
-    for quick checking of bit-accurate process runs as to whether bits will overflow when 
-    running on hardware.
+class AbstractBitCheckModel(AbstractPyBitCheckModel):
+    """Abstract implementation of BitCheck process. This
+    short and simple ProcessModel can be used for quick
+    checking of bit-accurate process runs as to whether
+    bits will overflow when running on hardware.
     """
 
     ref: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
@@ -47,12 +49,9 @@ class AbstractBitCheckModel (AbstractPyBitCheckModel):
         value = self.ref.read()
 
         if self.debug == 1:
-            print("Value is: {} at time step: {}".format(
-                value,
-                self.time_step
-                )
-            )
-        
+            print("Value is: {} at time step: {}"
+                  .format(value, self.time_step))
+
         # If self.check_bit_overflow(value) is true,
         # the value overflowed the allowed bits from self.bits
         if self.check_bit_overflow(value):
@@ -60,40 +59,55 @@ class AbstractBitCheckModel (AbstractPyBitCheckModel):
             if self.debug == 1:
                 if self.layerid:
                     print("layer id number: {}".format(self.layerid))
-                print("value.max: overflows {} bits {}"
-                      .format(self.bits, value.max()))
-                print("max signed value {}"
-                      .format(self.max_signed_int_per_bits(self.bits)))
-                print("value.min: overflows {} bits {}"
-                      .format(self.bits, value.min()))
-                print("min signed value {}"
-                      .format(self.max_signed_int_per_bits(self.bits)))
+                print(
+                    "value.max: overflows {} bits {}".format(
+                        self.bits, value.max()
+                    )
+                )
+                print(
+                    "max signed value {}".format(
+                        self.max_signed_int_per_bits(self.bits)
+                    )
+                )
+                print(
+                    "value.min: overflows {} bits {}".format(
+                        self.bits, value.min()
+                    )
+                )
+                print(
+                    "min signed value {}".format(
+                        self.max_signed_int_per_bits(self.bits)
+                    )
+                )
 
     def check_bit_overflow(self, value: ty.Type[np.ndarray]):
         value = value.astype(np.int32)
         shift_amt = 32 - self.bits
-        # shift value left by shift_amt and 
+        # shift value left by shift_amt and
         # then shift value right by shift_amt
         # the result should equal unshifted value
         # if the value did not overflow bits in self.bits
-        return not np.all(((value << shift_amt) >> shift_amt) == value)
-    
+        return not np.all(
+            ((value << shift_amt) >> shift_amt) == value
+        )
+
     def max_unsigned_int_per_bits(bits):
         return (1 << bits) - 1
-    
+
     def min_signed_int_per_bits(bits):
         return -1 << (bits - 1)
-    
+
     def max_signed_int_per_bits(bits):
-        return (1 << (bits -1)) - 1
+        return (1 << (bits - 1)) - 1
 
 
 @implements(proc=BitCheck, protocol=LoihiProtocol)
 @requires(CPU)
-class LoihiBitCheckModel (AbstractBitCheckModel):
-    """Implementation of Loihi BitCheck process. This short and simple ProcessModel can be used 
-    for quick checking of Loihi bit-accurate process run as to whether bits will overflow when 
-    running on Loihi Hardware.
+class LoihiBitCheckModel(AbstractBitCheckModel):
+    """Implementation of Loihi BitCheck process. This
+    short and simple ProcessModel can be used for quick
+    checking of Loihi bit-accurate process run as to
+    whether bits will overflow when running on Loihi Hardware.
     """
 
     ref: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)

--- a/src/lava/proc/bit_check/models.py
+++ b/src/lava/proc/bit_check/models.py
@@ -21,7 +21,7 @@ class AbstractPyBitCheckModel(PyLoihiProcessModel):
     Specific implementations inherit from here.
     """
 
-    ref: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
+    state: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
 
     bits: int = LavaPyType(int, int)
     layerid: int = LavaPyType(int, int)
@@ -35,7 +35,7 @@ class AbstractBitCheckModel(AbstractPyBitCheckModel):
     bits will overflow when running on hardware.
     """
 
-    ref: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
+    state: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
 
     bits: int = LavaPyType(int, int)
     layerid: int = LavaPyType(int, int)
@@ -46,7 +46,7 @@ class AbstractBitCheckModel(AbstractPyBitCheckModel):
         return True
 
     def run_post_mgmt(self):
-        value = self.ref.read()
+        value = self.state.read()
 
         if self.debug == 1:
             print("Value is: {} at time step: {}"
@@ -110,7 +110,7 @@ class LoihiBitCheckModel(AbstractBitCheckModel):
     whether bits will overflow when running on Loihi Hardware.
     """
 
-    ref: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
+    state: PyRefPort = LavaPyType(PyRefPort.VEC_DENSE, int)
 
     bits: int = LavaPyType(int, int)
     layerid: int = LavaPyType(int, int)

--- a/src/lava/proc/bit_check/models.py
+++ b/src/lava/proc/bit_check/models.py
@@ -91,13 +91,13 @@ class AbstractBitCheckModel(AbstractPyBitCheckModel):
             ((value << shift_amt) >> shift_amt) == value
         )
 
-    def max_unsigned_int_per_bits(bits):
+    def max_unsigned_int_per_bits(self, bits: ty.Type[int]):
         return (1 << bits) - 1
 
-    def min_signed_int_per_bits(bits):
+    def min_signed_int_per_bits(self, bits: ty.Type[int]):
         return -1 << (bits - 1)
 
-    def max_signed_int_per_bits(bits):
+    def max_signed_int_per_bits(self, bits: ty.Type[int]):
         return (1 << (bits - 1)) - 1
 
 

--- a/src/lava/proc/bit_check/process.py
+++ b/src/lava/proc/bit_check/process.py
@@ -57,11 +57,6 @@ class BitCheck(AbstractProcess):
         else:
             raise ValueError("bits value is \
                              {} but should be 1-31".format(bits))
-        """
-        overflowed: int
-            0 by default, changed to 1 if overflow occurs
-            Default is 0.
-        """
         self._overflowed: ty.Type(Var) = Var(shape=shape, init=0)
 
     @property

--- a/src/lava/proc/bit_check/process.py
+++ b/src/lava/proc/bit_check/process.py
@@ -8,21 +8,22 @@ from lava.magma.core.process.process import LogConfig, AbstractProcess
 from lava.magma.core.process.ports.ports import RefPort
 from lava.magma.core.process.variable import Var
 
-class BitCheck (AbstractProcess):
+
+class BitCheck(AbstractProcess):
     def __init__(
-            self,
-            shape: ty.Tuple[int, ...] = (1,),
-            layerid: ty.Optional[int] = None,
-            debug: ty.Optional[int] = 0,
-            bits: ty.Optional[int] = 24,
-            name: ty.Optional[str] = None,
-            log_config: ty.Optional[LogConfig] = None,
-            **kwargs
-        ) -> None:
-        """BitCheck process. 
-        This process is used for quick checking of 
-        bit-accurate process run as to whether bits will overflow when 
-        running on bit sensitive hardware.
+        self,
+        shape: ty.Tuple[int, ...] = (1,),
+        layerid: ty.Optional[int] = None,
+        debug: ty.Optional[int] = 0,
+        bits: ty.Optional[int] = 24,
+        name: ty.Optional[str] = None,
+        log_config: ty.Optional[LogConfig] = None,
+        **kwargs,
+    ) -> None:
+        """BitCheck process.
+        This process is used for quick checking of
+        bit-accurate process run as to whether bits will
+        overflow when running on bit sensitive hardware.
 
         Parameters
         ----------
@@ -46,7 +47,7 @@ class BitCheck (AbstractProcess):
             **kwargs,
         )
         super().__init__(shape=shape, **kwargs)
-        
+
         self.ref = RefPort(shape=shape)
 
         self.layerid = Var(shape=shape, init=layerid)
@@ -54,7 +55,8 @@ class BitCheck (AbstractProcess):
         if bits <= 31 and bits >= 1:
             self.bits = Var(shape=shape, init=bits)
         else:
-            raise ValueError("bits value is {} but should be 1-31".format(bits))
+            raise ValueError("bits value is \
+                             {} but should be 1-31".format(bits))
         """
         overflowed: int
             0 by default, changed to 1 if overflow occurs
@@ -65,10 +67,10 @@ class BitCheck (AbstractProcess):
     @property
     def shape(self) -> ty.Tuple[int, ...]:
         """Return shape of the Process."""
-        return self.proc_params['shape']
-    
+        return self.proc_params["shape"]
+
     @property
     def overflowed(self) -> ty.Type[int]:
-        """Return overflow Var of Process. 
+        """Return overflow Var of Process.
         1 is overflowed, 0 is not overflowed"""
         return self._overflowed.get()

--- a/src/lava/proc/bit_check/process.py
+++ b/src/lava/proc/bit_check/process.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+# See: https://spdx.org/licenses/
+
+import typing as ty
+
+from lava.magma.core.process.process import LogConfig, AbstractProcess
+from lava.magma.core.process.ports.ports import RefPort
+from lava.magma.core.process.variable import Var
+
+class BitCheck (AbstractProcess):
+    def __init__(
+            self,
+            shape: ty.Tuple[int, ...] = (1,),
+            layerid: ty.Optional[int] = None,
+            debug: ty.Optional[int] = 0,
+            bits: ty.Optional[int] = 24,
+            name: ty.Optional[str] = None,
+            log_config: ty.Optional[LogConfig] = None,
+            **kwargs
+        ) -> None:
+        """BitCheck process. 
+        This process is used for quick checking of 
+        bit-accurate process run as to whether bits will overflow when 
+        running on bit sensitive hardware.
+
+        Parameters
+        ----------
+        shape: Tuple
+            shape of the sigma process.
+            Default is (1,).
+        layerid: int or float
+            layer number of network.
+            Default is None.
+        debug: 0 or 1
+            Enable (1) or disable (0) debug print.
+            Default is 0.
+        bits: int
+            bits to use when checking overflow, 1-32
+            Default is 24.
+        """
+        super().__init__(
+            shape=shape,
+            name=name,
+            log_config=log_config,
+            **kwargs,
+        )
+        super().__init__(shape=shape, **kwargs)
+        
+        self.ref = RefPort(shape=shape)
+
+        self.layerid = Var(shape=shape, init=layerid)
+        self.debug = Var(shape=shape, init=debug)
+        if bits <= 31 and bits >= 1:
+            self.bits = Var(shape=shape, init=bits)
+        else:
+            raise ValueError("bits value is {} but should be 1-31".format(bits))
+        """
+        overflowed: int
+            0 by default, changed to 1 if overflow occurs
+            Default is 0.
+        """
+        self._overflowed: ty.Type(Var) = Var(shape=shape, init=0)
+
+    @property
+    def shape(self) -> ty.Tuple[int, ...]:
+        """Return shape of the Process."""
+        return self.proc_params['shape']
+    
+    @property
+    def overflowed(self) -> ty.Type[int]:
+        """Return overflow Var of Process. 
+        1 is overflowed, 0 is not overflowed"""
+        return self._overflowed.get()

--- a/src/lava/proc/bit_check/process.py
+++ b/src/lava/proc/bit_check/process.py
@@ -23,21 +23,21 @@ class BitCheck(AbstractProcess):
         """BitCheck process.
         This process is used for quick checking of
         bit-accurate process run as to whether bits will
-        overflow when running on bit sensitive hardware.
+        overflow when running on bit limited hardware.
 
         Parameters
         ----------
         shape: Tuple
-            shape of the sigma process.
+            Shape of the sigma process.
             Default is (1,).
         layerid: int or float
-            layer number of network.
+            Layer number of network.
             Default is None.
         debug: 0 or 1
             Enable (1) or disable (0) debug print.
             Default is 0.
         bits: int
-            bits to use when checking overflow, 1-32
+            Bits to use when checking overflow, 1-32.
             Default is 24.
         """
         super().__init__(
@@ -89,5 +89,5 @@ class BitCheck(AbstractProcess):
     @property
     def overflowed(self) -> ty.Type[int]:
         """Return overflow Var of Process.
-        1 is overflowed, 0 is not overflowed"""
+        1 is overflowed, 0 is not overflowed."""
         return self._overflowed.get()

--- a/tests/lava/proc/bit_check/test_models.py
+++ b/tests/lava/proc/bit_check/test_models.py
@@ -56,7 +56,7 @@ class TestBitCheckModels(unittest.TestCase):
         return self.input_, output, bits_used, overflowed
 
     def test_bitcheck_sigma_decoding_fixed_overflow(self) -> None:
-        """Test BitCheck with overflow sigma decode."""
+        """Test BitCheck with overflow sigma decode"""
         _, _, bitcheck_bits, bitcheck_overflowed = self.run_test(
             num_steps=self.num_steps, tag="fixed_pt", bits=12
         )
@@ -68,7 +68,7 @@ class TestBitCheckModels(unittest.TestCase):
         self.assertTrue(bitcheck_bits == 12)
 
     def test_bitcheck_sigma_decoding_fixed(self) -> None:
-        """Test BitCheck no overflow sigma decode."""
+        """Test BitCheck no overflow sigma decode"""
         _, _, bitcheck_bits, bitcheck_overflowed = self.run_test(
             num_steps=self.num_steps, tag="fixed_pt", bits=24
         )
@@ -81,7 +81,7 @@ class TestBitCheckModels(unittest.TestCase):
 
 
 class TestBitcheckSigmaDelta(unittest.TestCase):
-    """Test BitCheck with sigma delta neurons."""
+    """Test BitCheck with sigma delta neurons"""
     num_steps = 100
     spike_exp = 6
     state_exp = 6

--- a/tests/lava/proc/bit_check/test_models.py
+++ b/tests/lava/proc/bit_check/test_models.py
@@ -13,21 +13,18 @@ from lava.proc.bit_check.process import BitCheck
 from lava.proc.sdn.process import Sigma, SigmaDelta, ActivationMode
 from lava.proc import io
 
-verbose = True if (('-v' in sys.argv) or ('--verbose' in sys.argv)) else False
+verbose = True if (("-v" in sys.argv) or ("--verbose" in sys.argv)) else False
 
 
 class TestBitCheckModels(unittest.TestCase):
     """Tests for BitCheck Models"""
 
     def run_test(
-        self,
-        num_steps: int,
-        tag: str = 'fixed_pt',
-        bits: int = 24
+        self, num_steps: int, tag: str = "fixed_pt", bits: int = 24
     ) -> Tuple[np.ndarray, np.ndarray]:
         input_ = np.sin(0.1 * np.arange(num_steps).reshape(1, -1))
-        if tag == 'fixed_pt':
-            input_ *= (1 << 12)
+        if tag == "fixed_pt":
+            input_ *= 1 << 12
             input_ = input_.astype(int)
         input_[:, 1:] -= input_[:, :-1]
 
@@ -41,7 +38,9 @@ class TestBitCheckModels(unittest.TestCase):
         debug = 0
         if verbose:
             debug = 1
-        bitcheck = BitCheck(shape=sigma.shape, layerid=1, bits=bits, debug=debug)
+        bitcheck = BitCheck(
+            shape=sigma.shape, layerid=1, bits=bits, debug=debug
+        )
         bitcheck.ref.connect_var(sigma.sigma)
 
         run_condition = RunSteps(num_steps=num_steps)
@@ -64,9 +63,7 @@ class TestBitCheckModels(unittest.TestCase):
         bitcheck_overflowed = None
 
         _, _, bitcheck_bits, bitcheck_overflowed = self.run_test(
-            num_steps=num_steps,
-            tag='fixed_pt',
-            bits=12
+            num_steps=num_steps, tag="fixed_pt", bits=12
         )
 
         if verbose:
@@ -74,15 +71,13 @@ class TestBitCheckModels(unittest.TestCase):
             print("bitcheck_bits: ", bitcheck_bits)
         self.assertTrue(bitcheck_overflowed == 1)
         self.assertTrue(bitcheck_bits == 12)
-    
+
     def test_sigma_decoding_fixed(self) -> None:
         """Test BitCheck no overflow sigma decode."""
         num_steps = 100
 
-        _, _, bitcheck_bits, bitcheck_overflowed  = self.run_test(
-            num_steps=num_steps,
-            tag='fixed_pt',
-            bits=24
+        _, _, bitcheck_bits, bitcheck_overflowed = self.run_test(
+            num_steps=num_steps, tag="fixed_pt", bits=24
         )
 
         if verbose:
@@ -103,11 +98,11 @@ class TestBitcheckSigmaDelta(unittest.TestCase):
         spike_exp: int,
         state_exp: int,
         cum_error: bool,
-        tag: str = 'fixed_pt',
-        bits: int = 24
+        tag: str = "fixed_pt",
+        bits: int = 24,
     ) -> Tuple[np.ndarray, np.ndarray]:
         input_ = np.sin(0.1 * np.arange(num_steps).reshape(1, -1))
-        input_ *= (1 << spike_exp + state_exp)
+        input_ *= 1 << spike_exp + state_exp
         input_[:, 1:] -= input_[:, :-1]
 
         source = io.source.RingBuffer(data=input_.astype(int) * (1 << 6))
@@ -117,7 +112,7 @@ class TestBitcheckSigmaDelta(unittest.TestCase):
             act_mode=act_mode,
             spike_exp=spike_exp,
             state_exp=state_exp,
-            cum_error=cum_error
+            cum_error=cum_error,
         )
         sink = io.sink.RingBuffer(shape=sdn.shape, buffer=num_steps)
 
@@ -145,8 +140,7 @@ class TestBitcheckSigmaDelta(unittest.TestCase):
         return input_, output, bits_used, overflowed
 
     def test_reconstruction_fixed(self) -> None:
-        """Tests BitCheck with fixed point sigma delta reconstruction
-        """
+        """Tests BitCheck with fixed point sigma delta reconstruction"""
         num_steps = 100
         spike_exp = 6
         state_exp = 6
@@ -158,7 +152,7 @@ class TestBitcheckSigmaDelta(unittest.TestCase):
             spike_exp=spike_exp,
             state_exp=state_exp,
             cum_error=False,
-            bits=24
+            bits=24,
         )
 
         if verbose:
@@ -168,20 +162,20 @@ class TestBitcheckSigmaDelta(unittest.TestCase):
         self.assertTrue(bitcheck_bits == 24)
 
     def test_reconstruction_fixed_overflow(self) -> None:
-        """Tests BitCheck overflow with fixed point sigma delta reconstruction
-        """
+        """Tests BitCheck overflow with fixed point
+        sigma delta reconstruction"""
         num_steps = 100
         spike_exp = 6
         state_exp = 6
         vth = 10 << (spike_exp + state_exp)
-        _, _, bitcheck_bits, bitcheck_overflowed  = self.run_test(
+        _, _, bitcheck_bits, bitcheck_overflowed = self.run_test(
             num_steps=num_steps,
             vth=vth,
             act_mode=ActivationMode.UNIT,
             spike_exp=spike_exp,
             state_exp=state_exp,
             cum_error=False,
-            bits=12
+            bits=12,
         )
 
         if verbose:
@@ -189,4 +183,3 @@ class TestBitcheckSigmaDelta(unittest.TestCase):
             print("bitcheck_bits: ", bitcheck_bits)
         self.assertTrue(bitcheck_overflowed == 1)
         self.assertTrue(bitcheck_bits == 12)
-

--- a/tests/lava/proc/bit_check/test_models.py
+++ b/tests/lava/proc/bit_check/test_models.py
@@ -56,7 +56,7 @@ class TestBitCheckModels(unittest.TestCase):
 
         return input_, output, bits_used, overflowed
 
-    def test_sigma_decoding_fixed_overflow(self) -> None:
+    def test_bitcheck_sigma_decoding_fixed_overflow(self) -> None:
         """Test BitCheck with overflow sigma decode."""
         num_steps = 100
         bitcheck_bits = None
@@ -72,7 +72,7 @@ class TestBitCheckModels(unittest.TestCase):
         self.assertTrue(bitcheck_overflowed == 1)
         self.assertTrue(bitcheck_bits == 12)
 
-    def test_sigma_decoding_fixed(self) -> None:
+    def test_bitcheck_sigma_decoding_fixed(self) -> None:
         """Test BitCheck no overflow sigma decode."""
         num_steps = 100
 
@@ -139,7 +139,7 @@ class TestBitcheckSigmaDelta(unittest.TestCase):
 
         return input_, output, bits_used, overflowed
 
-    def test_reconstruction_fixed(self) -> None:
+    def test_bitcheck_reconstruction_fixed(self) -> None:
         """Tests BitCheck with fixed point sigma delta reconstruction"""
         num_steps = 100
         spike_exp = 6
@@ -161,7 +161,7 @@ class TestBitcheckSigmaDelta(unittest.TestCase):
         self.assertTrue(bitcheck_overflowed == 0)
         self.assertTrue(bitcheck_bits == 24)
 
-    def test_reconstruction_fixed_overflow(self) -> None:
+    def test_bitcheck_reconstruction_fixed_overflow(self) -> None:
         """Tests BitCheck overflow with fixed point
         sigma delta reconstruction"""
         num_steps = 100

--- a/tests/lava/proc/bit_check/test_models.py
+++ b/tests/lava/proc/bit_check/test_models.py
@@ -1,0 +1,192 @@
+# Copyright (C) 2021-22 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+# See: https://spdx.org/licenses/
+
+import sys
+import unittest
+import numpy as np
+from typing import Tuple
+
+from lava.magma.core.run_configs import Loihi1SimCfg
+from lava.magma.core.run_conditions import RunSteps
+from lava.proc.bit_check.process import BitCheck
+from lava.proc.sdn.process import Sigma, SigmaDelta, ActivationMode
+from lava.proc import io
+
+verbose = True if (('-v' in sys.argv) or ('--verbose' in sys.argv)) else False
+
+
+class TestBitCheckModels(unittest.TestCase):
+    """Tests for BitCheck Models"""
+
+    def run_test(
+        self,
+        num_steps: int,
+        tag: str = 'fixed_pt',
+        bits: int = 24
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        input_ = np.sin(0.1 * np.arange(num_steps).reshape(1, -1))
+        if tag == 'fixed_pt':
+            input_ *= (1 << 12)
+            input_ = input_.astype(int)
+        input_[:, 1:] -= input_[:, :-1]
+
+        source = io.source.RingBuffer(data=input_)
+        sigma = Sigma(shape=(1,))
+        sink = io.sink.RingBuffer(shape=sigma.shape, buffer=num_steps)
+
+        source.s_out.connect(sigma.a_in)
+        sigma.s_out.connect(sink.a_in)
+
+        debug = 0
+        if verbose:
+            debug = 1
+        bitcheck = BitCheck(shape=sigma.shape, layerid=1, bits=bits, debug=debug)
+        bitcheck.ref.connect_var(sigma.sigma)
+
+        run_condition = RunSteps(num_steps=num_steps)
+        run_config = Loihi1SimCfg(select_tag=tag)
+
+        sigma.run(condition=run_condition, run_cfg=run_config)
+        output = sink.data.get()
+
+        bits_used = bitcheck.bits.get()
+        overflowed = bitcheck.overflowed
+
+        sigma.stop()
+
+        return input_, output, bits_used, overflowed
+
+    def test_sigma_decoding_fixed_overflow(self) -> None:
+        """Test BitCheck with overflow sigma decode."""
+        num_steps = 100
+        bitcheck_bits = None
+        bitcheck_overflowed = None
+
+        _, _, bitcheck_bits, bitcheck_overflowed = self.run_test(
+            num_steps=num_steps,
+            tag='fixed_pt',
+            bits=12
+        )
+
+        if verbose:
+            print("bitcheck_overflowed: ", bitcheck_overflowed)
+            print("bitcheck_bits: ", bitcheck_bits)
+        self.assertTrue(bitcheck_overflowed == 1)
+        self.assertTrue(bitcheck_bits == 12)
+    
+    def test_sigma_decoding_fixed(self) -> None:
+        """Test BitCheck no overflow sigma decode."""
+        num_steps = 100
+
+        _, _, bitcheck_bits, bitcheck_overflowed  = self.run_test(
+            num_steps=num_steps,
+            tag='fixed_pt',
+            bits=24
+        )
+
+        if verbose:
+            print("bitcheck_overflowed: ", bitcheck_overflowed)
+            print("bitcheck_bits: ", bitcheck_bits)
+        self.assertTrue(bitcheck_overflowed == 0)
+        self.assertTrue(bitcheck_bits == 24)
+
+
+class TestBitcheckSigmaDelta(unittest.TestCase):
+    """Test BitCheck with sigma delta neurons."""
+
+    def run_test(
+        self,
+        num_steps: int,
+        vth: int,
+        act_mode: ActivationMode,
+        spike_exp: int,
+        state_exp: int,
+        cum_error: bool,
+        tag: str = 'fixed_pt',
+        bits: int = 24
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        input_ = np.sin(0.1 * np.arange(num_steps).reshape(1, -1))
+        input_ *= (1 << spike_exp + state_exp)
+        input_[:, 1:] -= input_[:, :-1]
+
+        source = io.source.RingBuffer(data=input_.astype(int) * (1 << 6))
+        sdn = SigmaDelta(
+            shape=(1,),
+            vth=vth,
+            act_mode=act_mode,
+            spike_exp=spike_exp,
+            state_exp=state_exp,
+            cum_error=cum_error
+        )
+        sink = io.sink.RingBuffer(shape=sdn.shape, buffer=num_steps)
+
+        source.s_out.connect(sdn.a_in)
+        sdn.s_out.connect(sink.a_in)
+
+        debug = 0
+        if verbose:
+            debug = 1
+        bitcheck = BitCheck(shape=sdn.shape, layerid=1, bits=bits, debug=debug)
+        bitcheck.ref.connect_var(sdn.sigma)
+
+        run_condition = RunSteps(num_steps=num_steps)
+        run_config = Loihi1SimCfg(select_tag=tag)
+
+        sdn.run(condition=run_condition, run_cfg=run_config)
+        output = sink.data.get()
+        bits_used = bitcheck.bits.get()
+        overflowed = bitcheck.overflowed
+        sdn.stop()
+
+        input_ = np.cumsum(input_, axis=1)
+        output = np.cumsum(output, axis=1)
+
+        return input_, output, bits_used, overflowed
+
+    def test_reconstruction_fixed(self) -> None:
+        """Tests BitCheck with fixed point sigma delta reconstruction
+        """
+        num_steps = 100
+        spike_exp = 6
+        state_exp = 6
+        vth = 10 << (spike_exp + state_exp)
+        _, _, bitcheck_bits, bitcheck_overflowed = self.run_test(
+            num_steps=num_steps,
+            vth=vth,
+            act_mode=ActivationMode.UNIT,
+            spike_exp=spike_exp,
+            state_exp=state_exp,
+            cum_error=False,
+            bits=24
+        )
+
+        if verbose:
+            print("bitcheck_overflowed: ", bitcheck_overflowed)
+            print("bitcheck_bits: ", bitcheck_bits)
+        self.assertTrue(bitcheck_overflowed == 0)
+        self.assertTrue(bitcheck_bits == 24)
+
+    def test_reconstruction_fixed_overflow(self) -> None:
+        """Tests BitCheck overflow with fixed point sigma delta reconstruction
+        """
+        num_steps = 100
+        spike_exp = 6
+        state_exp = 6
+        vth = 10 << (spike_exp + state_exp)
+        _, _, bitcheck_bits, bitcheck_overflowed  = self.run_test(
+            num_steps=num_steps,
+            vth=vth,
+            act_mode=ActivationMode.UNIT,
+            spike_exp=spike_exp,
+            state_exp=state_exp,
+            cum_error=False,
+            bits=12
+        )
+
+        if verbose:
+            print("bitcheck_overflowed: ", bitcheck_overflowed)
+            print("bitcheck_bits: ", bitcheck_bits)
+        self.assertTrue(bitcheck_overflowed == 1)
+        self.assertTrue(bitcheck_bits == 12)
+

--- a/tests/lava/proc/bit_check/test_models.py
+++ b/tests/lava/proc/bit_check/test_models.py
@@ -38,9 +38,9 @@ class TestBitCheckModels(unittest.TestCase):
         if verbose:
             debug = 1
         bitcheck = BitCheck(
-            shape=sigma.shape, layerid=1, bits=bits, debug=debug
+            layerid=1, bits=bits, debug=debug
         )
-        bitcheck.ref.connect_var(sigma.sigma)
+        bitcheck.state.connect_var(sigma.sigma)
 
         run_condition = RunSteps(num_steps=num_steps)
         run_config = Loihi1SimCfg(select_tag=tag)
@@ -119,8 +119,8 @@ class TestBitcheckSigmaDelta(unittest.TestCase):
         debug = 0
         if verbose:
             debug = 1
-        bitcheck = BitCheck(shape=sdn.shape, layerid=1, bits=bits, debug=debug)
-        bitcheck.ref.connect_var(sdn.sigma)
+        bitcheck = BitCheck(layerid=1, bits=bits, debug=debug)
+        bitcheck.state.connect_var(sdn.sigma)
 
         run_condition = RunSteps(num_steps=num_steps)
         run_config = Loihi1SimCfg(select_tag=tag)

--- a/tests/lava/proc/bit_check/test_process.py
+++ b/tests/lava/proc/bit_check/test_process.py
@@ -4,6 +4,7 @@
 
 import unittest
 from lava.proc.bit_check.process import BitCheck
+from lava.magma.core.process.variable import Var
 
 
 class TestBitCheck(unittest.TestCase):
@@ -12,17 +13,24 @@ class TestBitCheck(unittest.TestCase):
     def test_init(self) -> None:
         """Tests instantiation of BitCheck"""
         bc = BitCheck(shape=(2, 3, 4), layerid=10, debug=1, bits=12)
+        self.assertEqual(bc.shape, (1,))
+        bc.connect_var(Var(shape=(2, 3, 4)))
         self.assertEqual(bc.shape, (2, 3, 4))
         self.assertEqual(bc.layerid.get(), 10)
         self.assertEqual(bc.debug.get(), 1)
         self.assertEqual(bc.bits.get(), 12)
-        bc01 = BitCheck(shape=(1,))
+
+        bc01 = BitCheck(shape=(2,))
+        self.assertEqual(bc01.shape, (1,))
+        bc01.connect_var(Var(shape=(1,)))
         self.assertEqual(bc01.shape, (1,))
         self.assertEqual(bc01.layerid.init, None)
         self.assertEqual(bc01.debug.init, 0)
         self.assertEqual(bc01.bits.init, 24)
         bc02 = BitCheck()
         self.assertEqual(bc02.shape, (1,))
+        bc02.connect_var(Var(shape=(2, 3, 3)))
+        self.assertEqual(bc02.shape, (2, 3, 3))
 
         bitcheckers = []
         for i in range(1, 31):

--- a/tests/lava/proc/bit_check/test_process.py
+++ b/tests/lava/proc/bit_check/test_process.py
@@ -8,6 +8,7 @@ from lava.proc.bit_check.process import BitCheck
 
 class TestBitCheck(unittest.TestCase):
     """Tests for BitCheck class"""
+
     def test_init(self) -> None:
         """Tests instantiation of BitCheck"""
         bc = BitCheck(shape=(2, 3, 4), layerid=10, debug=1, bits=12)
@@ -24,12 +25,12 @@ class TestBitCheck(unittest.TestCase):
         self.assertEqual(bc02.shape, (1,))
 
         bitcheckers = []
-        for i in range(1,31):
+        for i in range(1, 31):
             bitcheckers.append(BitCheck(bits=i))
             self.assertEqual(bitcheckers[i - 1].bits.init, i)
-        
+
     def test_init_bits_exception(self) -> None:
-        """Tests instantiation of BitCheck throws 
+        """Tests instantiation of BitCheck throws
         error on incorrect bits parameter"""
         with self.assertRaises(ValueError):
             BitCheck(bits=0)

--- a/tests/lava/proc/bit_check/test_process.py
+++ b/tests/lava/proc/bit_check/test_process.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+# See: https://spdx.org/licenses/
+
+import unittest
+from lava.proc.bit_check.process import BitCheck
+
+
+class TestBitCheck(unittest.TestCase):
+    """Tests for BitCheck class"""
+    def test_init(self) -> None:
+        """Tests instantiation of BitCheck"""
+        bc = BitCheck(shape=(2, 3, 4), layerid=10, debug=1, bits=12)
+        self.assertEqual(bc.shape, (2, 3, 4))
+        self.assertEqual(bc.layerid.get(), 10)
+        self.assertEqual(bc.debug.get(), 1)
+        self.assertEqual(bc.bits.get(), 12)
+        bc01 = BitCheck(shape=(1,))
+        self.assertEqual(bc01.shape, (1,))
+        self.assertEqual(bc01.layerid.init, None)
+        self.assertEqual(bc01.debug.init, 0)
+        self.assertEqual(bc01.bits.init, 24)
+        bc02 = BitCheck()
+        self.assertEqual(bc02.shape, (1,))
+
+        bitcheckers = []
+        for i in range(1,31):
+            bitcheckers.append(BitCheck(bits=i))
+            self.assertEqual(bitcheckers[i - 1].bits.init, i)
+        
+    def test_init_bits_exception(self) -> None:
+        """Tests instantiation of BitCheck throws 
+        error on incorrect bits parameter"""
+        with self.assertRaises(ValueError):
+            BitCheck(bits=0)
+        with self.assertRaises(ValueError):
+            BitCheck(bits=32)

--- a/tutorials/in_depth/tutorial10_sigma_delta_neurons.ipynb
+++ b/tutorials/in_depth/tutorial10_sigma_delta_neurons.ipynb
@@ -215,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 5,
    "id": "9799bc7a",
    "metadata": {},
    "outputs": [],
@@ -244,9 +244,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "sigma_process_key='Process_48'\n",
-      "delta_process_key='Process_46'\n",
-      "bc_overflowed=array([0.])\n"
+      "sigma_process_key='Process_4'\n",
+      "delta_process_key='Process_2'\n",
+      "bc_overflowed=False\n"
      ]
     }
    ],
@@ -265,7 +265,7 @@
     "neuron_act = mon3.get_data()[sigma_process_key]['act']\n",
     "neuron_sigma = mon4.get_data()[sigma_process_key]['sigma']\n",
     "delta_out = mon5.get_data()[delta_process_key]['s_out']\n",
-    "bc_overflowed = bc.overflowed\n",
+    "bc_overflowed = bool(bc.overflowed)\n",
     "neuron.stop()\n",
     "\n",
     "print(f'{bc_overflowed=}')"

--- a/tutorials/in_depth/tutorial10_sigma_delta_neurons.ipynb
+++ b/tutorials/in_depth/tutorial10_sigma_delta_neurons.ipynb
@@ -48,6 +48,7 @@
     "from lava.proc.dense.process import Dense\n",
     "from lava.proc.sdn.process import SigmaDelta, ActivationMode, Delta\n",
     "from lava.proc.monitor.process import Monitor\n",
+    "from lava.proc.bit_check.process import BitCheck\n",
     "from lava.magma.core.run_conditions import RunSteps\n",
     "from lava.magma.core.run_configs import Loihi2SimCfg"
    ]
@@ -204,6 +205,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "59881029",
+   "metadata": {},
+   "source": [
+    "## Create sigma overflow check\n",
+    "\n",
+    "We can check that the sigma neuron is not overflowing 24-bit value using the BitCheck process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "9799bc7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bc = BitCheck(bits=24)\n",
+    "bc.state.connect_var(neuron.sigma)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "28906da2-d392-4360-bcfc-0786ae2bd8c7",
    "metadata": {},
    "source": [
@@ -214,20 +236,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 31,
    "id": "79bed4bf-7c10-4933-8294-2277e92e0919",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sigma_process_key='Process_48'\n",
+      "delta_process_key='Process_46'\n",
+      "bc_overflowed=array([0.])\n"
+     ]
+    }
+   ],
    "source": [
     "neuron.run(condition=RunSteps(num_steps=t_sim), \n",
     "           run_cfg=Loihi2SimCfg(select_tag='floating_pt'))\n",
     "\n",
-    "neuron_out = mon.get_data()['Process_4']['s_out']\n",
-    "neuron_act = mon3.get_data()['Process_4']['act']\n",
-    "neuron_residue = mon2.get_data()['Process_4']['residue']\n",
-    "neuron_sigma = mon4.get_data()['Process_4']['sigma']\n",
-    "delta_out = mon5.get_data()['Process_2']['s_out']\n",
-    "neuron.stop()"
+    "\n",
+    "sigma_process_key = next(iter(mon.get_data()))\n",
+    "print (f'{sigma_process_key=}')\n",
+    "delta_process_key = next(iter(mon5.get_data()))\n",
+    "print (f'{delta_process_key=}')\n",
+    "\n",
+    "neuron_out = mon.get_data()[sigma_process_key]['s_out']\n",
+    "neuron_residue = mon2.get_data()[sigma_process_key]['residue']\n",
+    "neuron_act = mon3.get_data()[sigma_process_key]['act']\n",
+    "neuron_sigma = mon4.get_data()[sigma_process_key]['sigma']\n",
+    "delta_out = mon5.get_data()[delta_process_key]['s_out']\n",
+    "bc_overflowed = bc.overflowed\n",
+    "neuron.stop()\n",
+    "\n",
+    "print(f'{bc_overflowed=}')"
    ]
   },
   {


### PR DESCRIPTION
Issue Number: #801

Objective of pull request: Add a BitCheck process. This short and simple ProcessModel can be used for quick checking of bit-accurate process runs as to whether bits will overflow when running on hardware.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
-   [X] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [X] Tests are part of the PR (for bug fixes / features)
-   [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [X] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [X] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [X] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [X] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
-   [X] Feature



## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- Currently there is not a standard way to check if process vars overflow particular bit limitations during bit-accurate runs meant to simulate hardware.

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- BitCheck process is added that gives a standard way to check if process vars overflow particular bit limitations during bit-accurate runs meant to simulate hardware.

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

-   [ ] Yes
-   [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information
During Loihi verification against Lava bit-accurate simulation we found that it was useful to have an overflow checker. This PR and feature request is the result of that realization.

Suggestions and design ideas happily accepted.
