### PR TITLE
Add plotting utils for process diragram

### DIFF
--- a/src/lava/magma/compiler/compiler_graphs.py
+++ b/src/lava/magma/compiler/compiler_graphs.py
@@ -406,6 +406,16 @@ class ProcDiGraph(DiGraphBase):
 
             self.annotate_digraph_by_degree()
 
+        if proc_list:
+
+            import networkx as nx
+            import matplotlib.pyplot as plt
+
+            plt.clf()
+            pos = nx.spring_layout(self, k=0.3, iterations=40)
+            nx.draw_networkx(self, pos, with_labels=True, labels=node_name_dict)
+            plt.savefig("process_diagram.png")
+
     @staticmethod
     def _get_port_direction(port: AbstractPort) -> str:
         """Determines the connectivity direction of a Port.


### PR DESCRIPTION
Objective of pull request: add plotting utils to obtain a diagram of processes and connections after compilation

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
-   [ ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [ ] Tests are part of the PR (for bug fixes / features)
-   [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [ ] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [ ] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [ ] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [ ] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation changes
-   [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
-

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
-

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

-   [ ] Yes
-   [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
