### PR TITLE
Alternative to Injector/Extractor Processes

### DIFF
--- a/src/lava/magma/core/process/ports/ports.py
+++ b/src/lava/magma/core/process/ports/ports.py
@@ -432,6 +432,17 @@ class OutPort(AbstractIOPort, AbstractSrcPort):
     sub processes.
     """
 
+    def __init__(self, shape: ty.Tuple[int, ...]):
+        super().__init__(shape)
+        self.external_pipe_flag = False
+        self.external_pipe_buffer_size = 64
+
+    def flag_external_pipe(self, buffer_size=None):
+        self.external_pipe_flag = True
+
+        if buffer_size is not None:
+            self.external_pipe_buffer_size = buffer_size
+
     def connect(
             self,
             ports: ty.Union["AbstractIOPort", ty.List["AbstractIOPort"]],
@@ -492,6 +503,15 @@ class InPort(AbstractIOPort, AbstractDstPort):
     ):
         super().__init__(shape)
         self._reduce_op = reduce_op
+
+        self.external_pipe_flag = False
+        self.external_pipe_buffer_size = 64
+
+    def flag_external_pipe(self, buffer_size=None):
+        self.external_pipe_flag = True
+
+        if buffer_size is not None:
+            self.external_pipe_buffer_size = buffer_size
 
     def connect(self,
                 ports: ty.Union["InPort", ty.List["InPort"]],

--- a/src/lava/magma/runtime/runtime.py
+++ b/src/lava/magma/runtime/runtime.py
@@ -311,7 +311,7 @@ class Runtime:
 
                     # Create any external pypychannels
                     self._create_external_channels(proc, proc_builder)
-                    
+
                     self._messaging_infrastructure.build_actor(target_fn,
                                                                proc_builder,
                                                                exception_q)

--- a/src/lava/proc/io/extractor.py
+++ b/src/lava/proc/io/extractor.py
@@ -89,7 +89,8 @@ class Extractor(AbstractProcess):
                                  "<create_runtime> or <run> on your Lava"
                                  " network before using <send>.")
 
-        elements_in_buffer = self.out_port.external_pipe_csp_recv_port._queue.qsize()
+        elements_in_buffer = \
+            self.out_port.external_pipe_csp_recv_port._queue.qsize()
 
         if elements_in_buffer == 0:
             data = self._receive_when_empty(

--- a/src/lava/proc/io/extractor.py
+++ b/src/lava/proc/io/extractor.py
@@ -6,13 +6,13 @@ import numpy as np
 import typing as ty
 
 from lava.magma.core.process.process import AbstractProcess
-from lava.magma.core.process.ports.ports import InPort, RefPort, Var
+from lava.magma.core.process.ports.ports import InPort, OutPort, RefPort, Var
 from lava.magma.core.resources import CPU
 from lava.magma.core.decorator import implements, requires
 from lava.magma.core.model.py.model import PyLoihiProcessModel
 from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
 from lava.magma.core.model.py.type import LavaPyType
-from lava.magma.core.model.py.ports import PyInPort, PyRefPort
+from lava.magma.core.model.py.ports import PyInPort, PyOutPort, PyRefPort
 from lava.magma.compiler.channels.pypychannel import PyPyChannel
 from lava.magma.runtime.message_infrastructure.multiprocessing import \
     MultiProcessing
@@ -51,9 +51,9 @@ class Extractor(AbstractProcess):
     def __init__(self,
                  shape: ty.Tuple[int, ...],
                  buffer_size: ty.Optional[int] = 50,
-                 channel_config: ty.Optional[utils.ChannelConfig] = None) -> \
-            None:
-        super().__init__()
+                 channel_config: ty.Optional[utils.ChannelConfig] = None,
+                 **kwargs) -> None:
+        super().__init__(shape_1=shape, **kwargs)
 
         channel_config = channel_config or utils.ChannelConfig()
 
@@ -63,78 +63,64 @@ class Extractor(AbstractProcess):
 
         self._shape = shape
 
-        self._multi_processing = MultiProcessing()
-        self._multi_processing.start()
-
-        # Stands for ProcessModel to Process
-        pm_to_p = PyPyChannel(message_infrastructure=self._multi_processing,
-                              src_name="src",
-                              dst_name="dst",
-                              shape=self._shape,
-                              dtype=float,
-                              size=buffer_size)
-        self._pm_to_p_dst_port = pm_to_p.dst_port
-        self._pm_to_p_dst_port.start()
-
         self.proc_params["channel_config"] = channel_config
-        self.proc_params["pm_to_p_src_port"] = pm_to_p.src_port
 
         self._receive_when_empty = channel_config.get_receive_empty_function()
         self._receive_when_not_empty = \
             channel_config.get_receive_not_empty_function()
 
-        self.in_port = InPort(shape=self._shape)
+        self.in_port = InPort(shape=shape)
+        self.out_port = OutPort(shape=shape)
+        self.out_port.flag_external_pipe(buffer_size=buffer_size)
 
     def receive(self) -> np.ndarray:
         """Receive data from the ProcessModel.
 
-        The data is received from pm_to_p.dst_port.
+        The data is received from out_port.
 
         Returns
         ----------
         data : np.ndarray
             Data received.
         """
-        elements_in_buffer = self._pm_to_p_dst_port._queue.qsize()
+        if not hasattr(self.out_port, 'external_pipe_csp_recv_port'):
+            raise AssertionError("The Runtime needs to be created before"
+                                 "calling <send>. Please use the method "
+                                 "<create_runtime> or <run> on your Lava"
+                                 " network before using <send>.")
+
+        elements_in_buffer = self.out_port.external_pipe_csp_recv_port._queue.qsize()
 
         if elements_in_buffer == 0:
             data = self._receive_when_empty(
-                self._pm_to_p_dst_port,
+                self.out_port.external_pipe_csp_recv_port,
                 np.zeros(self._shape))
         else:
             data = self._receive_when_not_empty(
-                self._pm_to_p_dst_port,
+                self.out_port.external_pipe_csp_recv_port,
                 np.zeros(self._shape),
                 elements_in_buffer)
 
         return data
 
-    def __del__(self) -> None:
-        super().__del__()
-
-        self._multi_processing.stop()
-        self._pm_to_p_dst_port.join()
-
 
 @implements(proc=Extractor, protocol=LoihiProtocol)
 @requires(CPU)
 class PyLoihiExtractorModel(PyLoihiProcessModel):
+    """PyLoihiProcessModel for the Extractor Process."""
     in_port: PyInPort = LavaPyType(PyInPort.VEC_DENSE, float)
+    out_port: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, float)
 
     def __init__(self, proc_params: dict) -> None:
         super().__init__(proc_params=proc_params)
 
         channel_config = self.proc_params["channel_config"]
-        self._pm_to_p_src_port = self.proc_params["pm_to_p_src_port"]
-        self._pm_to_p_src_port.start()
 
         self._send = channel_config.get_send_full_function()
 
     def run_spk(self) -> None:
-        self._send(self._pm_to_p_src_port, self.in_port.recv())
-
-    def __del__(self) -> None:
-        self._pm_to_p_src_port.join()
+        self._send(self.out_port.csp_ports[-1],
+                   self.in_port.recv())
 
 
 class VarWire(AbstractProcess):

--- a/src/lava/proc/io/injector.py
+++ b/src/lava/proc/io/injector.py
@@ -6,16 +6,13 @@ import numpy as np
 import typing as ty
 
 from lava.magma.core.process.process import AbstractProcess
-from lava.magma.core.process.ports.ports import OutPort
+from lava.magma.core.process.ports.ports import InPort, OutPort
 from lava.magma.core.resources import CPU
 from lava.magma.core.decorator import implements, requires
 from lava.magma.core.model.py.model import PyLoihiProcessModel
 from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
 from lava.magma.core.model.py.type import LavaPyType
-from lava.magma.core.model.py.ports import PyOutPort
-from lava.magma.runtime.message_infrastructure.multiprocessing import \
-    MultiProcessing
-from lava.magma.compiler.channels.pypychannel import PyPyChannel
+from lava.magma.core.model.py.ports import PyInPort, PyOutPort
 from lava.proc.io import utils
 
 
@@ -47,13 +44,12 @@ class Injector(AbstractProcess):
         buffer is full and how the dst_port behaves when the buffer is empty
         and not empty.
     """
-
     def __init__(self,
                  shape: ty.Tuple[int, ...],
                  buffer_size: ty.Optional[int] = 50,
-                 channel_config: ty.Optional[utils.ChannelConfig] = None) -> \
-            None:
-        super().__init__()
+                 channel_config: ty.Optional[utils.ChannelConfig] = None,
+                 **kwargs) ->  None:
+        super().__init__(shape_1=shape, **kwargs)
 
         channel_config = channel_config or utils.ChannelConfig()
 
@@ -61,50 +57,43 @@ class Injector(AbstractProcess):
         utils.validate_buffer_size(buffer_size)
         utils.validate_channel_config(channel_config)
 
-        self._multi_processing = MultiProcessing()
-        self._multi_processing.start()
-
-        # Stands for Process to ProcessModel
-        p_to_pm = PyPyChannel(message_infrastructure=self._multi_processing,
-                              src_name="src",
-                              dst_name="dst",
-                              shape=shape,
-                              dtype=float,
-                              size=buffer_size)
-        self._p_to_pm_src_port = p_to_pm.src_port
-        self._p_to_pm_src_port.start()
+        self.in_port = InPort(shape=shape)
+        self.in_port.flag_external_pipe(buffer_size=buffer_size)
+        self.out_port = OutPort(shape=shape)
 
         self.proc_params["shape"] = shape
         self.proc_params["channel_config"] = channel_config
-        self.proc_params["p_to_pm_dst_port"] = p_to_pm.dst_port
 
         self._send = channel_config.get_send_full_function()
-
-        self.out_port = OutPort(shape=shape)
-
+    
     def send(self, data: np.ndarray) -> None:
-        """Send data to the ProcessModel.
-
-        The data is sent through p_to_pm.src_port.
+        """Send data to connected process.
 
         Parameters
         ----------
         data : np.ndarray
             Data to be sent.
+        
+        Raises
+        ------
+        AssertionError
+            If the runtime of the Lava network was not created.
         """
-        self._send(self._p_to_pm_src_port, data)
-
-    def __del__(self) -> None:
-        super().__del__()
-
-        self._multi_processing.stop()
-        self._p_to_pm_src_port.join()
+        # The csp channel is created by the runtime
+        if hasattr(self.in_port, 'external_pipe_csp_send_port'):
+            self._send(self.in_port.external_pipe_csp_send_port, data)
+        else:
+            raise AssertionError("The Runtime needs to be created before"
+                                 "calling <send>. Please use the method "
+                                 "<create_runtime> or <run> on your Lava"
+                                 " network before using <send>.")
 
 
 @implements(proc=Injector, protocol=LoihiProtocol)
 @requires(CPU)
 class PyLoihiInjectorModel(PyLoihiProcessModel):
     """PyLoihiProcessModel for the Injector Process."""
+    in_port: PyInPort = LavaPyType(PyInPort.VEC_DENSE, float)
     out_port: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, float)
 
     def __init__(self, proc_params: dict) -> None:
@@ -112,9 +101,6 @@ class PyLoihiInjectorModel(PyLoihiProcessModel):
 
         shape = self.proc_params["shape"]
         channel_config = self.proc_params["channel_config"]
-        self._p_to_pm_dst_port = self.proc_params["p_to_pm_dst_port"]
-        self._p_to_pm_dst_port.start()
-
         self._zeros = np.zeros(shape)
 
         self._receive_when_empty = channel_config.get_receive_empty_function()
@@ -123,19 +109,16 @@ class PyLoihiInjectorModel(PyLoihiProcessModel):
 
     def run_spk(self) -> None:
         self._zeros.fill(0)
-        elements_in_buffer = self._p_to_pm_dst_port._queue.qsize()
+        elements_in_buffer = self.in_port.csp_ports[-1]._queue.qsize()
 
         if elements_in_buffer == 0:
             data = self._receive_when_empty(
-                self._p_to_pm_dst_port,
+                self.in_port,
                 self._zeros)
         else:
             data = self._receive_when_not_empty(
-                self._p_to_pm_dst_port,
+                self.in_port,
                 self._zeros,
                 elements_in_buffer)
 
         self.out_port.send(data)
-
-    def __del__(self) -> None:
-        self._p_to_pm_dst_port.join()

--- a/src/lava/proc/io/injector.py
+++ b/src/lava/proc/io/injector.py
@@ -48,7 +48,7 @@ class Injector(AbstractProcess):
                  shape: ty.Tuple[int, ...],
                  buffer_size: ty.Optional[int] = 50,
                  channel_config: ty.Optional[utils.ChannelConfig] = None,
-                 **kwargs) ->  None:
+                 **kwargs) -> None:
         super().__init__(shape_1=shape, **kwargs)
 
         channel_config = channel_config or utils.ChannelConfig()
@@ -65,7 +65,7 @@ class Injector(AbstractProcess):
         self.proc_params["channel_config"] = channel_config
 
         self._send = channel_config.get_send_full_function()
-    
+
     def send(self, data: np.ndarray) -> None:
         """Send data to connected process.
 
@@ -73,7 +73,7 @@ class Injector(AbstractProcess):
         ----------
         data : np.ndarray
             Data to be sent.
-        
+
         Raises
         ------
         AssertionError

--- a/tests/lava/magma/runtime/test_external_pipe_io.py
+++ b/tests/lava/magma/runtime/test_external_pipe_io.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: LGPL 2.1 or later
+# See: https://spdx.org/licenses/
+import threading
+import unittest
+import typing as ty
+
+import numpy as np
+
+from lava.magma.core.decorator import implements, requires
+from lava.magma.core.model.py.model import PyLoihiProcessModel
+from lava.magma.core.model.py.ports import PyOutPort, PyInPort
+from lava.magma.core.model.py.type import LavaPyType
+from lava.magma.core.process.ports.ports import OutPort, InPort
+from lava.magma.core.process.process import AbstractProcess
+from lava.magma.core.resources import CPU
+from lava.magma.core.sync.protocols.loihi_protocol import LoihiProtocol
+from lava.magma.core.run_conditions import RunSteps
+from lava.magma.core.run_configs import Loihi2SimCfg
+
+
+class Process1(AbstractProcess):
+    def __init__(self, shape_1: ty.Tuple, **kwargs):
+        super().__init__(shape_1=shape_1, **kwargs)
+
+        self.in_1 = InPort(shape=shape_1)
+        self.out_1 = OutPort(shape=shape_1)
+
+
+@implements(proc=Process1, protocol=LoihiProtocol)
+@requires(CPU)
+class LoihiDenseSpkPyProcess1PM(PyLoihiProcessModel):
+    in_1: PyInPort = LavaPyType(PyInPort.VEC_DENSE, float)
+    out_1: PyOutPort = LavaPyType(PyOutPort.VEC_DENSE, float)
+
+    def __init__(self, proc_params):
+        super().__init__(proc_params)
+
+    def run_spk(self):
+        print(f"Receiving in Process...")
+        data_1 = self.in_1.recv()
+        print(f"Received {data_1} in Process...")
+
+        print(f"Sending {data_1} from Process...")
+        self.out_1.send(data_1)
+        print(f"Sent {data_1} from Process!")
+
+
+class TestExternalPipeIO(unittest.TestCase):
+    def test_run_steps_non_blocking(self):
+        data = [[1], [2], [3], [4], [5]]
+
+        relay = Process1(shape_1=(1,))
+        # Control buffer size with buffer_size arg, default is 64
+        relay.in_1.flag_external_pipe()
+        # Control buffer size with buffer_size arg, default is 64
+        relay.out_1.flag_external_pipe()
+
+        run_cfg = Loihi2SimCfg()
+        run_condition = RunSteps(num_steps=5, blocking=False)
+
+        def thread_inject_fn() -> None:
+            for send_data_single_item in data:
+                print(f"Sending {send_data_single_item} from thread_inject...")
+                # Use probe() before send() to know whether or not send() will
+                # block (i.e if the buffer of external_pipe_csp_send_port
+                # is full).
+                relay.in_1.external_pipe_csp_send_port.send(
+                    np.array(send_data_single_item))
+                print(f"Sent {send_data_single_item} from thread_inject!")
+
+        def thread_extract_fn() -> None:
+            for _ in range(len(data)):
+                print(f"Receiving in thread_extract...")
+                # Use probe() before recv() to know whether or not recv() will
+                # block (i.e if the buffer of external_pipe_csp_recv_port
+                # is empty).
+                received_data = relay.out_1.external_pipe_csp_recv_port.recv()
+                print(f"Received {received_data} in thread_extract!")
+
+        thread_inject = threading.Thread(target=thread_inject_fn,
+                                         daemon=True)
+        thread_extract = threading.Thread(target=thread_extract_fn,
+                                          daemon=True)
+
+        relay.run(condition=run_condition, run_cfg=run_cfg)
+
+        thread_inject.start()
+        thread_extract.start()
+
+        relay.wait()
+        relay.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/lava/proc/io/test_injector.py
+++ b/tests/lava/proc/io/test_injector.py
@@ -79,9 +79,6 @@ class TestInjector(unittest.TestCase):
         self.assertEqual(config.receive_empty, utils.ReceiveEmpty.BLOCKING)
         self.assertEqual(config.receive_not_empty, utils.ReceiveNotEmpty.FIFO)
 
-        self.assertIsInstance(injector.proc_params["p_to_pm_dst_port"],
-                              CspRecvPort)
-
         self.assertIsInstance(injector.out_port, OutPort)
         self.assertEqual(injector.out_port.shape, out_shape)
 
@@ -212,6 +209,8 @@ class TestPyLoihiInjectorModel(unittest.TestCase):
 
         run_condition = RunSteps(num_steps=num_steps)
         run_cfg = Loihi2SimCfg()
+        ex = injector.compile(run_cfg=run_cfg)
+        injector.create_runtime(run_cfg=run_cfg, executable=ex)
 
         shared_queue = Queue(2)
 
@@ -299,6 +298,8 @@ class TestPyLoihiInjectorModel(unittest.TestCase):
 
         run_condition = RunSteps(num_steps=num_steps)
         run_cfg = Loihi2SimCfg()
+        ex = injector.compile(run_cfg=run_cfg)
+        injector.create_runtime(run_cfg=run_cfg, executable=ex)
 
         injector.send(np.ones(data_shape))
         injector.run(condition=run_condition, run_cfg=run_cfg)
@@ -405,6 +406,8 @@ class TestPyLoihiInjectorModel(unittest.TestCase):
 
         run_condition = RunSteps(num_steps=num_steps)
         run_cfg = Loihi2SimCfg()
+        ex = injector.compile(run_cfg=run_cfg)
+        injector.create_runtime(run_cfg=run_cfg, executable=ex)
 
         injector.send(send_data[0])
         injector.send(send_data[1])
@@ -457,6 +460,8 @@ class TestPyLoihiInjectorModel(unittest.TestCase):
 
         run_condition = RunSteps(num_steps=num_steps)
         run_cfg = Loihi2SimCfg()
+        ex = injector.compile(run_cfg=run_cfg)
+        injector.create_runtime(run_cfg=run_cfg, executable=ex)
 
         def thread_2_fn() -> None:
             for send_data_single_item in data:
@@ -468,6 +473,7 @@ class TestPyLoihiInjectorModel(unittest.TestCase):
         injector.run(condition=run_condition, run_cfg=run_cfg)
         recv_var_data = recv.var.get()
         injector.stop()
+        thread_2.join()
 
         np.testing.assert_equal(recv_var_data, data)
 


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: Give an alternative (better) implementation of Injector and Extractor main functionality without wrapping it into a Lava Process.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
-   [ ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [ ] Tests are part of the PR (for bug fixes / features)
-   [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [ ] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [ ] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [ ] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [ ] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation changes
-   [x] Other (please describe): Alternative implementation of a feature


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- Injector and Extractor Processes are used to communicate data in and out of Lava.

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- Communication between Lava and the outside would be done differently. The API would look like this:
```python
relay = Relay(shape=(1,)) # Process with an InPort (in_1) and an OutPort (out_1)
...
relay.run(condition=RunStep(num_steps=1, blocking=False), ...)
...
send_data = np.array([5])
relay.in_1.external_pipe_csv_send_port.send(send_data)
...
recv_data = relay.out_1.external_pipe_csv_recv_port.recv()
```
- Advantages of this alternative:
  - Uses the same MultiProcessing instance as the Runtime (addressing pending problem highlighted in #686).
  - Communication to/from the target Lava ports is direct, while with the Injector/Extractor, it had to go through an intermediary channel.

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

-   [x] Yes
-   [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
- **If we delete the Injector and Extractor Processes in this PR**, any code using them has to be adapted to use the alternative instead.