### PR TITLE
Fix: subthreshold dynamics equation of refractory lif

### DIFF
--- a/src/lava/proc/lif/models.py
+++ b/src/lava/proc/lif/models.py
@@ -477,9 +477,8 @@ class PyLifRefractoryModelFloat(AbstractPyLifModelFloat):
         self.u[:] = self.u * (1 - self.du)
         self.u[:] += activation_in
         non_refractory = self.refractory_period_end < self.time_step
-        self.v[non_refractory] = (self.v[non_refractory] * (
-            (1 - self.dv) + self.u[non_refractory])
-            + self.bias_mant[non_refractory])
+        self.v[non_refractory] = self.v[non_refractory] * (1 - self.dv) + (
+            self.u[non_refractory] + self.bias_mant[non_refractory])
 
     def process_spikes(self, spike_vector: np.ndarray):
         self.refractory_period_end[spike_vector] = (self.time_step


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request:

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
-   [x] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [ ] Tests are part of the PR (for bug fixes / features)
-   [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [ ] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation changes
-   [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- The `PyLifRefractoryModelFloat` model does not update the voltage correctly in its sub-threshold dynamics. The current equation is:
![image](https://github.com/lava-nc/lava/assets/28673635/8f86aa0e-5d3e-4b79-928a-1d361f683667)
Therefore, the voltage of the neurons is updated incorrectly.

## What is the new behavior?
- The correct dynamics of the voltage should be: 
![image](https://github.com/lava-nc/lava/assets/28673635/844dafe6-4d9b-4b7d-ba3e-f9fadc1b4ea8)
so the new behavior uses this new equation.

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
