### PR TITLE
Enable manual partitioning

### DIFF
--- a/src/lava/magma/compiler/subcompilers/py/pyproc_compiler.py
+++ b/src/lava/magma/compiler/subcompilers/py/pyproc_compiler.py
@@ -89,7 +89,8 @@ class PyProcCompiler(SubCompiler):
         super().__init__(proc_group, compile_config)
         self._spike_io_counter_offset: Offset = Offset()
 
-    def compile(self, channel_map: ChannelMap) -> ChannelMap:
+    def compile(self, channel_map: ChannelMap,
+                partitioning: ty.Dict = {}) -> ChannelMap:
         return self._update_channel_map(channel_map)
 
     def __del__(self):

--- a/src/lava/magma/compiler/subcompilers/py/pyproc_compiler.py
+++ b/src/lava/magma/compiler/subcompilers/py/pyproc_compiler.py
@@ -90,7 +90,7 @@ class PyProcCompiler(SubCompiler):
         self._spike_io_counter_offset: Offset = Offset()
 
     def compile(self, channel_map: ChannelMap,
-                partitioning: ty.Dict = {}) -> ChannelMap:
+                partitioning: ty.Dict = None) -> ChannelMap:
         return self._update_channel_map(channel_map)
 
     def __del__(self):

--- a/tests/lava/magma/compiler/test_compiler.py
+++ b/tests/lava/magma/compiler/test_compiler.py
@@ -217,7 +217,8 @@ def create_patches(
     and the compile() method returns the given ChannelMap unchanged.
     ."""
 
-    def compile_return(channel_map: ChannelMap) -> ChannelMap:
+    def compile_return(channel_map: ChannelMap,
+                       partitioning=None) -> ChannelMap:
         return channel_map
 
     py_patch = patch(
@@ -397,7 +398,7 @@ class TestCompiler(unittest.TestCase):
         # exactly once. After that, the while loop should exit because the
         # ChannelMap instance has not changed.
         for sc in subcompilers:
-            sc.compile.assert_called_once_with({})
+            sc.compile.assert_called_once_with({}, None)
 
     def test_compile_proc_group_multiple_loops(self) -> None:
         """Test whether the correct methods are called on all objects when
@@ -431,7 +432,7 @@ class TestCompiler(unittest.TestCase):
         # exactly once. After that, the while loop should exit because the
         # ChannelMap instance has not changed.
         for sc in subcompilers:
-            sc.compile.assert_called_with({**channel_map1, **channel_map2})
+            sc.compile.assert_called_with({**channel_map1, **channel_map2}, None)
             self.assertEqual(sc.compile.call_count, 3)
 
     def test_extract_proc_builders(self) -> None:
@@ -512,7 +513,7 @@ class TestCompiler(unittest.TestCase):
         with py_patch:
             # Call the method to be tested.
             proc_builders, channel_map = self.compiler._compile_proc_groups(
-                proc_groups, channel_map, None
+                proc_groups, channel_map
             )
 
         # There should be six Process Builders...

--- a/tests/lava/magma/compiler/test_compiler.py
+++ b/tests/lava/magma/compiler/test_compiler.py
@@ -432,7 +432,8 @@ class TestCompiler(unittest.TestCase):
         # exactly once. After that, the while loop should exit because the
         # ChannelMap instance has not changed.
         for sc in subcompilers:
-            sc.compile.assert_called_with({**channel_map1, **channel_map2}, None)
+            sc.compile.assert_called_with({**channel_map1, **channel_map2},
+                                          None)
             self.assertEqual(sc.compile.call_count, 3)
 
     def test_extract_proc_builders(self) -> None:

--- a/tests/lava/magma/compiler/test_compiler.py
+++ b/tests/lava/magma/compiler/test_compiler.py
@@ -391,7 +391,7 @@ class TestCompiler(unittest.TestCase):
         subcompilers = [py_proc_compiler]
 
         # Call the method to be tested.
-        self.compiler._compile_proc_group(subcompilers, channel_map)
+        self.compiler._compile_proc_group(subcompilers, channel_map, None)
 
         # Check that it called compile() on every SubCompiler instance
         # exactly once. After that, the while loop should exit because the
@@ -424,7 +424,8 @@ class TestCompiler(unittest.TestCase):
         subcompilers = [py_proc_compiler]
 
         # Call the method to be tested.
-        self.compiler._compile_proc_group(subcompilers, channel_map)
+        self.compiler._compile_proc_group(subcompilers, channel_map,
+                                          None)
 
         # Check that it called compile() on every SubCompiler instance
         # exactly once. After that, the while loop should exit because the
@@ -511,7 +512,7 @@ class TestCompiler(unittest.TestCase):
         with py_patch:
             # Call the method to be tested.
             proc_builders, channel_map = self.compiler._compile_proc_groups(
-                proc_groups, channel_map
+                proc_groups, channel_map, None
             )
 
         # There should be six Process Builders...


### PR DESCRIPTION

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: It should be possible to give a set partitioning to the compiler to bypass the iterative finding of a partitioning.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
-   [ ] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [ ] Tests are part of the PR (for bug fixes / features)
-   [x] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [x] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation changes
-   [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
-

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
-

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
