### PR TITLE
GeneralRunConfig for Hardware-Based Config Selection

### DIFF
--- a/tests/lava/magma/core/test_run_configs.py
+++ b/tests/lava/magma/core/test_run_configs.py
@@ -1,0 +1,76 @@
+"""Unit Tests for RunConfigs.
+
+"""
+
+import unittest
+import logging
+
+from lava.magma.core.run_configs import (
+    Loihi2SimCfg, Loihi2HwCfg, GeneralRunCfg
+)
+from lava.magma.core.resources import CPU, Loihi2System, LMT
+
+class TestGeneralRunConfig(unittest.TestCase):
+    """Unit tests for the GeneralRunConfig class."""
+    def test_new(self):
+        """Test that the `__new__` function returns the correct `RunConfig`."""
+
+        cpu_run_cfg = GeneralRunCfg(hardware=CPU)
+        self.assertIsInstance(cpu_run_cfg, Loihi2SimCfg)
+
+        loihi2_run_cfg = GeneralRunCfg(hardware=Loihi2System)
+        self.assertIsInstance(loihi2_run_cfg, Loihi2HwCfg)
+
+        with self.assertRaises(KeyError):
+            GeneralRunCfg(hardware=LMT)
+
+    def test_cpu_config(self):
+        """Test instantiation of CPU run configs."""
+        hardware = CPU
+        run_cfg = GeneralRunCfg(hardware=hardware)
+
+        self.assertEqual(run_cfg.log.level, logging.WARNING)
+        self.assertEqual(run_cfg.custom_sync_domains, [])
+        self.assertEqual(run_cfg.select_tag, None)
+        self.assertEqual(run_cfg.select_sub_proc_model, False)
+        self.assertEqual(run_cfg.exception_proc_model_map, {})
+
+        # test with kwargs
+        run_cfg = GeneralRunCfg(
+            hardware=hardware,
+            select_tag='fixed_pt',
+            select_sub_proc_model=True,
+            loglevel=logging.INFO
+        )
+        self.assertEqual(run_cfg.log.level, logging.INFO)
+        self.assertEqual(run_cfg.custom_sync_domains, [])
+        self.assertEqual(run_cfg.select_tag, 'fixed_pt')
+        self.assertEqual(run_cfg.select_sub_proc_model, True)
+        self.assertEqual(run_cfg.exception_proc_model_map, {})
+
+    def test_loihi2_config(self):
+        """Test instantiation of Loihi2 run configs."""
+        hardware = Loihi2System
+        run_cfg = GeneralRunCfg(hardware=hardware)
+
+        self.assertEqual(run_cfg.log.level, logging.WARNING)
+        self.assertEqual(run_cfg.custom_sync_domains, [])
+        self.assertEqual(run_cfg.select_tag, None)
+        self.assertEqual(run_cfg.select_sub_proc_model, False)
+        self.assertEqual(run_cfg.exception_proc_model_map, {})
+        self.assertEqual(run_cfg.callback_fxs, [])
+        self.assertEqual(run_cfg.embedded_allocation_order, 1)
+
+        # test with kwargs
+        run_cfg = GeneralRunCfg(
+            hardware=hardware,
+            select_sub_proc_model=True,
+            loglevel=logging.INFO
+        )
+        self.assertEqual(run_cfg.log.level, logging.INFO)
+        self.assertEqual(run_cfg.custom_sync_domains, [])
+        self.assertEqual(run_cfg.select_tag, None)
+        self.assertEqual(run_cfg.select_sub_proc_model, True)
+        self.assertEqual(run_cfg.exception_proc_model_map, {})
+        self.assertEqual(run_cfg.callback_fxs, [])
+        self.assertEqual(run_cfg.embedded_allocation_order, 1)


### PR DESCRIPTION
<!-- For questions please refer to https://lava-nc.org/developer_guide.html#how-to-contribute-to-lava or ask in a comment below -->


<!-- All pull requests require an issue https://github.com/lava-nc/lava/issues -->

<!-- Insert issue here as "Issue Number: #XXXX", example "Issue Number: #19" -->
Issue Number: #900 

<!-- Insert one sentence pr objective here, can be copied from relevant issue. -->
Objective of pull request: Introduce `GeneralRunConfig` class which selects appropriate run config based on `hardware` parameter.

## Pull request checklist
<!--  (Mark with "x") -->
Your PR fulfills the following requirements:
-   [x] [Issue](https://github.com/lava-nc/lava/issues) created that explains the change and why it's needed
-   [x] Tests are part of the PR (for bug fixes / features)
-   [ ] [Docs](https://github.com/lava-nc/docs) reviewed and added / updated if needed (for bug fixes / features)
-   [x] PR conforms to [Coding Conventions](https://lava-nc.org/developer_guide.html#coding-conventions)
-   [x] [PR applys BSD 3-clause or LGPL2.1+ Licenses](https://lava-nc.org/developer_guide.html#add-a-license) to all code files
-   [x] Lint (`flakeheaven lint src/lava tests/`) and (`bandit -r src/lava/.`) pass locally
-   [x] Build tests (`pytest`) passes locally


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check your PR type:
<!--  (Mark one with "x") remove not chosen below -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Code style update (formatting, renaming)
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Build related changes
-   [ ] Documentation changes
-   [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, can be copied from relevant issue. -->
- User must choose a specific `RunConfig` class for the hardware they wish to run on.

## What is the new behavior?
<!-- Please describe the new behavior, can be copied from relevant issue. -->
- User can select `GeneralRunCfg` and parameterize the hardware the network is run on.

## Does this introduce a breaking change?
<!--  (Mark one with "x") remove not chosen below -->

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Supplemental information

<!-- Any other information that is important to this PR. -->
